### PR TITLE
Add UDP-based server discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,19 @@
 | 客户端（移动端）   | Flutter + PWA 支持                         |
 | 本地存储          | JSON 配置文件 / SQLite                    |
 | 通知实现          | Web Notification API / `plyer` / `notify-send` |
+
+## 🧭 ServerDiscovery 模块示例
+
+本仓库提供 `server_discovery.py` 用于在局域网内自动发现服务端。示例的实现基于 UDP 广播：
+
+```bash
+# 终端 1：启动模拟服务器
+python mock_server.py
+
+# 终端 2：运行发现脚本
+python server_discovery.py
+```
+
+脚本会在 3 秒内等待服务器响应，并打印发现的服务器 IP 地址；若未发现则输出 `No server found`。
+
+`test_discovery.py` 演示了如何在代码中启动模拟服务器并调用发现函数，可用于简单的功能测试。

--- a/mock_server.py
+++ b/mock_server.py
@@ -1,0 +1,19 @@
+import socket
+
+BROADCAST_PORT = 9999
+DISCOVERY_MESSAGE = b'DISCOVER_SERVER'
+RESPONSE_MESSAGE = b'SERVER_HERE'
+
+
+def run_mock_server():
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(('', BROADCAST_PORT))
+        print('Mock server started. Waiting for discovery messages...')
+        data, addr = sock.recvfrom(1024)
+        if data == DISCOVERY_MESSAGE:
+            sock.sendto(RESPONSE_MESSAGE, addr)
+            print(f'Responded to discovery from {addr}')
+
+if __name__ == '__main__':
+    run_mock_server()

--- a/server_discovery.py
+++ b/server_discovery.py
@@ -1,0 +1,44 @@
+import asyncio
+import socket
+
+BROADCAST_PORT = 9999
+BROADCAST_ADDR = '255.255.255.255'
+DISCOVERY_MESSAGE = b'DISCOVER_SERVER'
+RESPONSE_MESSAGE = b'SERVER_HERE'
+TIMEOUT = 3
+
+async def discover_server(timeout=TIMEOUT):
+    loop = asyncio.get_running_loop()
+    found = []
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.settimeout(timeout)
+        try:
+            sock.sendto(DISCOVERY_MESSAGE, (BROADCAST_ADDR, BROADCAST_PORT))
+        except OSError:
+            # Fallback to localhost broadcast when network is restricted
+            sock.sendto(DISCOVERY_MESSAGE, ('127.0.0.1', BROADCAST_PORT))
+        start = loop.time()
+        while True:
+            remain = timeout - (loop.time() - start)
+            if remain <= 0:
+                break
+            try:
+                data, addr = sock.recvfrom(1024)
+            except socket.timeout:
+                break
+            if data.startswith(RESPONSE_MESSAGE):
+                found.append(addr[0])
+    return found
+
+async def main():
+    servers = await discover_server()
+    if servers:
+        print('Found servers:')
+        for ip in servers:
+            print(f'  - {ip}')
+    else:
+        print('No server found')
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -1,0 +1,14 @@
+import asyncio
+import subprocess
+import time
+
+async def main():
+    server_proc = subprocess.Popen(['python', 'mock_server.py'])
+    time.sleep(0.5)  # give the server time to start
+    from server_discovery import discover_server
+    servers = await discover_server()
+    server_proc.terminate()
+    print('Servers found:', servers)
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- implement `server_discovery.py` to discover local servers via UDP broadcast
- add `mock_server.py` for simulating LAN server responses
- include `test_discovery.py` for a simple discovery demo
- document usage of ServerDiscovery in README

## Testing
- `python server_discovery.py` *(no server running)*
- `python mock_server.py &` followed by `python server_discovery.py`
- `python test_discovery.py`
- `python -m py_compile server_discovery.py mock_server.py test_discovery.py`


------
https://chatgpt.com/codex/tasks/task_e_6850189e87f88330a797a68a6dfec6f8