### PR TITLE
Add TimerManager with tests

### DIFF
--- a/tests/test_timer_manager.py
+++ b/tests/test_timer_manager.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from timer_manager import TimerManager
+
+
+def test_create_timer():
+    tm = TimerManager()
+    timer_id = tm.create_timer(10)
+    assert timer_id in tm.timers
+    assert tm.timers[timer_id].remaining == 10
+
+
+def test_tick_and_finish():
+    tm = TimerManager()
+    timer_id = tm.create_timer(5)
+    tm.tick(3)
+    assert tm.timers[timer_id].remaining == 2
+    assert not tm.timers[timer_id].finished
+    tm.tick(5)
+    assert tm.timers[timer_id].remaining == 0
+    assert tm.timers[timer_id].finished
+
+
+def test_pause_and_resume():
+    tm = TimerManager()
+    timer_id = tm.create_timer(10)
+    tm.pause_timer(timer_id)
+    tm.tick(5)
+    # should not decrease while paused
+    assert tm.timers[timer_id].remaining == 10
+    tm.resume_timer(timer_id)
+    tm.tick(4)
+    assert tm.timers[timer_id].remaining == 6
+
+
+def test_remove_timer():
+    tm = TimerManager()
+    timer_id = tm.create_timer(10)
+    tm.remove_timer(timer_id)
+    assert timer_id not in tm.timers

--- a/timer_manager.py
+++ b/timer_manager.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Timer:
+    duration: float
+    remaining: float
+    running: bool = True
+    finished: bool = False
+
+    def tick(self, seconds: float) -> None:
+        if self.running and not self.finished:
+            self.remaining -= seconds
+            if self.remaining <= 0:
+                self.remaining = 0
+                self.finished = True
+                self.running = False
+
+
+class TimerManager:
+    def __init__(self) -> None:
+        self.timers: Dict[int, Timer] = {}
+        self._next_id = 1
+
+    def create_timer(self, duration: float) -> int:
+        timer_id = self._next_id
+        self._next_id += 1
+        self.timers[timer_id] = Timer(duration=duration, remaining=duration)
+        return timer_id
+
+    def tick(self, seconds: float) -> None:
+        for timer in list(self.timers.values()):
+            timer.tick(seconds)
+
+    def pause_timer(self, timer_id: int) -> None:
+        timer = self.timers.get(timer_id)
+        if timer and not timer.finished:
+            timer.running = False
+
+    def resume_timer(self, timer_id: int) -> None:
+        timer = self.timers.get(timer_id)
+        if timer and not timer.finished:
+            timer.running = True
+
+    def remove_timer(self, timer_id: int) -> None:
+        self.timers.pop(timer_id, None)


### PR DESCRIPTION
## Summary
- implement `TimerManager` and simple `Timer` dataclass
- add pytest tests verifying create, tick, pause/resume and remove behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685018157a14833095f2d21a95515838