### PR TITLE
Implement FastAPI server with tests

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+from fastapi import HTTPException
+from typing import List, Dict
+
+from timer_manager import TimerManager, Timer
+
+app = FastAPI()
+
+manager = TimerManager()
+
+# store connected websockets
+websockets: List[WebSocket] = []
+
+async def broadcast_state() -> None:
+    data = {
+        timer_id: {
+            "duration": timer.duration,
+            "remaining": timer.remaining,
+            "running": timer.running,
+            "finished": timer.finished,
+        }
+        for timer_id, timer in manager.timers.items()
+    }
+    for ws in list(websockets):
+        try:
+            await ws.send_json(data)
+        except WebSocketDisconnect:
+            websockets.remove(ws)
+
+@app.post("/timers")
+async def create_timer(duration: float):
+    timer_id = manager.create_timer(duration)
+    await broadcast_state()
+    return {"timer_id": timer_id}
+
+@app.get("/timers")
+async def list_timers():
+    return {
+        timer_id: {
+            "duration": timer.duration,
+            "remaining": timer.remaining,
+            "running": timer.running,
+            "finished": timer.finished,
+        }
+        for timer_id, timer in manager.timers.items()
+    }
+
+@app.post("/timers/{timer_id}/pause")
+async def pause_timer(timer_id: int):
+    if timer_id not in manager.timers:
+        raise HTTPException(status_code=404, detail="Timer not found")
+    manager.pause_timer(timer_id)
+    await broadcast_state()
+    return JSONResponse(status_code=200, content={"status": "paused"})
+
+@app.post("/timers/{timer_id}/resume")
+async def resume_timer(timer_id: int):
+    if timer_id not in manager.timers:
+        raise HTTPException(status_code=404, detail="Timer not found")
+    manager.resume_timer(timer_id)
+    await broadcast_state()
+    return JSONResponse(status_code=200, content={"status": "resumed"})
+
+@app.delete("/timers/{timer_id}")
+async def remove_timer(timer_id: int):
+    if timer_id not in manager.timers:
+        raise HTTPException(status_code=404, detail="Timer not found")
+    manager.remove_timer(timer_id)
+    await broadcast_state()
+    return JSONResponse(status_code=200, content={"status": "removed"})
+
+@app.post("/tick")
+async def tick(seconds: float):
+    manager.tick(seconds)
+    await broadcast_state()
+    return {"status": "ticked"}
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    websockets.append(ws)
+    try:
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        websockets.remove(ws)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import json
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+
+from api_server import app, manager, websockets
+
+client = TestClient(app)
+
+
+def setup_function(function):
+    # reset manager state before each test
+    manager.timers.clear()
+    manager._next_id = 1
+    websockets.clear()
+
+
+def test_create_and_list_timers():
+    resp = client.post('/timers', params={'duration': 5})
+    assert resp.status_code == 200
+    timer_id = resp.json()['timer_id']
+
+    resp = client.get('/timers')
+    data = resp.json()
+    assert str(timer_id) in data or timer_id in data
+    tid = timer_id if timer_id in data else str(timer_id)
+    assert data[tid]['remaining'] == 5
+
+
+def test_pause_resume_tick_remove():
+    timer_id = client.post('/timers', params={'duration': 10}).json()['timer_id']
+    resp = client.post(f'/timers/{timer_id}/pause')
+    assert resp.status_code == 200
+    client.post('/tick', params={'seconds': 5})
+    # remaining should stay 10 because paused
+    data = client.get('/timers').json()
+    tid = timer_id if timer_id in data else str(timer_id)
+    assert data[tid]['remaining'] == 10
+
+    client.post(f'/timers/{timer_id}/resume')
+    client.post('/tick', params={'seconds': 3})
+    data = client.get('/timers').json()
+    tid = timer_id if timer_id in data else str(timer_id)
+    assert data[tid]['remaining'] == 7
+
+    client.delete(f'/timers/{timer_id}')
+    data = client.get('/timers').json()
+    assert str(timer_id) not in data and timer_id not in data
+
+
+def test_websocket_receives_updates():
+    with client.websocket_connect('/ws') as ws:
+        timer_id = client.post('/timers', params={'duration': 3}).json()['timer_id']
+        # first message after creation
+        ws.receive_json()
+        client.post('/tick', params={'seconds': 1})
+        message = ws.receive_json()
+        tid = str(timer_id)
+        assert message[tid]['remaining'] == 2


### PR DESCRIPTION
## Summary
- implement `api_server.py` with REST API and websocket support using FastAPI
- add comprehensive tests for the new API server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850bcc344ac83309006e9010132d933