### PR TITLE
Add async Notifier module with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ python server_discovery.py
 
 - `api_server.py`：FastAPI 服务端实现，提供计时器的 REST 接口和 WebSocket 广播。
 - `timer_manager.py`：内部计时器数据结构与管理逻辑。
+- `notifier.py`：监控計時器完成並執行自定義回調通知。
 - `server_discovery.py`：通过 UDP 广播发现局域网内的服务器。
 - `mock_server.py`：配合发现脚本使用的简易 UDP 模拟服务器。
 - `tests/`：pytest 单元测试，覆盖 API 与计时器管理逻辑。

--- a/notifier.py
+++ b/notifier.py
@@ -1,0 +1,48 @@
+"""Monitor timers and trigger notifications when they finish."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Awaitable, Callable, Set
+
+from timer_manager import TimerManager
+
+NotifyCallback = Callable[[int], Awaitable[None]]
+
+
+class Notifier:
+    """Monitor a :class:`TimerManager` and invoke a callback on timer completion."""
+
+    def __init__(self, manager: TimerManager, callback: NotifyCallback) -> None:
+        self.manager = manager
+        self.callback = callback
+        self._task: asyncio.Task[None] | None = None
+        self._interval = 1.0
+        self._notified: Set[int] = set()
+        self._running = False
+
+    async def start(self, interval: float = 1.0) -> None:
+        """Start monitoring timers."""
+        if self._task:
+            return
+        self._interval = interval
+        self._running = True
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Stop monitoring timers."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        self._task = None
+
+    async def _run(self) -> None:
+        while self._running:
+            for tid, timer in list(self.manager.timers.items()):
+                if timer.finished and tid not in self._notified:
+                    await self.callback(tid)
+                    self._notified.add(tid)
+            await asyncio.sleep(self._interval)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 httpx
 requests
 pytest
+pytest-asyncio
+httpie

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,52 @@
+import asyncio
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from timer_manager import TimerManager
+from notifier import Notifier
+
+
+@pytest.mark.asyncio
+async def test_notifier_triggers_on_finish():
+    tm = TimerManager()
+    timer_id = tm.create_timer(5)
+
+    received: list[int] = []
+
+    async def on_notify(tid: int) -> None:
+        received.append(tid)
+
+    notifier = Notifier(tm, on_notify)
+    await notifier.start(interval=0.01)
+
+    tm.tick(5)
+    await asyncio.sleep(0.05)
+    await notifier.stop()
+
+    assert timer_id in received
+
+
+@pytest.mark.asyncio
+async def test_notifier_only_once():
+    tm = TimerManager()
+    timer_id = tm.create_timer(2)
+
+    count = 0
+
+    async def on_notify(tid: int) -> None:
+        nonlocal count
+        count += 1
+
+    notifier = Notifier(tm, on_notify)
+    await notifier.start(interval=0.01)
+
+    tm.tick(2)
+    await asyncio.sleep(0.03)
+    tm.tick(1)
+    await asyncio.sleep(0.03)
+    await notifier.stop()
+
+    assert count == 1 and timer_id in tm.timers


### PR DESCRIPTION
## Summary
- introduce `notifier.py` to observe `TimerManager` and run callbacks when timers finish
- document Notifier in README
- add pytest-asyncio and httpie to requirements for async tests and CLI tests
- add `tests/test_notifier.py` covering notification behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851048e76c083309909b03203e32a38