### PR TITLE
Improve timer validation and tests

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -38,6 +38,9 @@ async def broadcast_state() -> None:
 async def create_timer(duration: float):
     """Create a new timer with the given duration in seconds."""
 
+    if duration <= 0:
+        raise HTTPException(status_code=400, detail="Duration must be positive")
+
     timer_id = manager.create_timer(duration)
     await broadcast_state()
     return {"timer_id": timer_id}

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -61,3 +61,14 @@ def test_websocket_receives_updates():
         message = ws.receive_json()
         tid = str(timer_id)
         assert message[tid]['remaining'] == 2
+
+
+def test_create_timer_invalid_duration():
+    resp = client.post('/timers', params={'duration': -1})
+    assert resp.status_code == 400
+    assert resp.json()['detail'] == 'Duration must be positive'
+
+
+def test_pause_invalid_timer():
+    resp = client.post('/timers/999/pause')
+    assert resp.status_code == 404

--- a/tests/test_timer_manager.py
+++ b/tests/test_timer_manager.py
@@ -41,3 +41,16 @@ def test_remove_timer():
     timer_id = tm.create_timer(10)
     tm.remove_timer(timer_id)
     assert timer_id not in tm.timers
+
+
+def test_create_timer_non_positive_duration():
+    tm = TimerManager()
+    tid_zero = tm.create_timer(0)
+    zero_timer = tm.timers[tid_zero]
+    assert zero_timer.remaining == 0
+    assert zero_timer.finished
+
+    tid_neg = tm.create_timer(-5)
+    neg_timer = tm.timers[tid_neg]
+    assert neg_timer.remaining == 0
+    assert neg_timer.finished

--- a/timer_manager.py
+++ b/timer_manager.py
@@ -33,10 +33,22 @@ class TimerManager:
         self._next_id = 1
 
     def create_timer(self, duration: float) -> int:
-        """Create a new timer and return its identifier."""
+        """Create a new timer and return its identifier.
+
+        A duration less than or equal to zero will create a timer that is
+        immediately finished. This mirrors the behaviour of ticking a timer
+        down to zero but avoids exposing negative remaining times.
+        """
+
         timer_id = self._next_id
         self._next_id += 1
-        self.timers[timer_id] = Timer(duration=duration, remaining=duration)
+
+        if duration <= 0:
+            timer = Timer(duration=duration, remaining=0, running=False, finished=True)
+        else:
+            timer = Timer(duration=duration, remaining=duration)
+
+        self.timers[timer_id] = timer
         return timer_id
 
     def tick(self, seconds: float) -> None:


### PR DESCRIPTION
## Summary
- validate duration in API server
- handle zero/negative durations in `TimerManager`
- add regression tests for invalid durations and missing timers

## Testing
- `pytest -q`
- `coverage run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510511228c8330bfe19dd9252fbd7a