### PR TITLE
Fix zero-duration timer handling

### DIFF
--- a/tests/test_timer_manager.py
+++ b/tests/test_timer_manager.py
@@ -41,3 +41,12 @@ def test_remove_timer():
     timer_id = tm.create_timer(10)
     tm.remove_timer(timer_id)
     assert timer_id not in tm.timers
+
+
+def test_zero_duration_timer_finishes_immediately():
+    tm = TimerManager()
+    timer_id = tm.create_timer(0)
+    timer = tm.timers[timer_id]
+    assert timer.finished
+    assert not timer.running
+    assert timer.remaining == 0

--- a/timer_manager.py
+++ b/timer_manager.py
@@ -11,6 +11,12 @@ class Timer:
     running: bool = True
     finished: bool = False
 
+    def __post_init__(self) -> None:
+        if self.duration <= 0:
+            self.remaining = 0
+            self.running = False
+            self.finished = True
+
     def tick(self, seconds: float) -> None:
         if self.running and not self.finished:
             self.remaining -= seconds


### PR DESCRIPTION
## Summary
- ensure timers created with zero duration start finished
- test timer creation with zero duration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c4ca11d4833080f466a0ca821407