### PR TITLE
Add SyncService client module with tests

### DIFF
--- a/sync_service.py
+++ b/sync_service.py
@@ -1,0 +1,86 @@
+"""Client-side SyncService for real-time timer updates via WebSocket.
+
+This module provides a simple client that keeps a local copy of timer states
+synchronized with the server via WebSocket, while also offering convenience
+methods to control timers through the REST API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Dict, Optional
+import contextlib
+
+import httpx
+import websockets
+
+
+@dataclass
+class TimerState:
+    """Representation of a single timer's state."""
+
+    duration: float
+    remaining: float
+    running: bool
+    finished: bool
+
+
+class SyncService:
+    """Maintain WebSocket sync with the API server and expose REST helpers."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.ws_url = self.base_url.replace("http", "ws", 1) + "/ws"
+        self.client = httpx.AsyncClient(base_url=self.base_url)
+        self.state: Dict[str, TimerState] = {}
+        self._ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._recv_task: Optional[asyncio.Task[None]] = None
+
+    async def connect(self) -> None:
+        """Establish the WebSocket connection and start the receive loop."""
+        self._ws = await websockets.connect(self.ws_url)
+        self._recv_task = asyncio.create_task(self._recv_loop())
+
+    async def _recv_loop(self) -> None:
+        assert self._ws is not None
+        try:
+            async for message in self._ws:
+                data = json.loads(message)
+                self.state = {
+                    str(tid): TimerState(**info) for tid, info in data.items()
+                }
+        except websockets.ConnectionClosed:
+            pass
+
+    async def close(self) -> None:
+        """Close WebSocket connection and HTTP client."""
+        if self._ws is not None:
+            await self._ws.close()
+        if self._recv_task is not None:
+            self._recv_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._recv_task
+        await self.client.aclose()
+
+    async def create_timer(self, duration: float) -> int:
+        resp = await self.client.post("/timers", params={"duration": duration})
+        resp.raise_for_status()
+        return resp.json()["timer_id"]
+
+    async def pause_timer(self, timer_id: int) -> None:
+        resp = await self.client.post(f"/timers/{timer_id}/pause")
+        resp.raise_for_status()
+
+    async def resume_timer(self, timer_id: int) -> None:
+        resp = await self.client.post(f"/timers/{timer_id}/resume")
+        resp.raise_for_status()
+
+    async def remove_timer(self, timer_id: int) -> None:
+        resp = await self.client.delete(f"/timers/{timer_id}")
+        resp.raise_for_status()
+
+    async def tick(self, seconds: float) -> None:
+        resp = await self.client.post("/tick", params={"seconds": seconds})
+        resp.raise_for_status()

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -1,0 +1,69 @@
+import asyncio
+import time
+import subprocess
+import pytest
+
+from sync_service import SyncService
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_server():
+    proc = subprocess.Popen([
+        "uvicorn",
+        "api_server:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8002",
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # wait for startup
+    for _ in range(10):
+        try:
+            import requests
+
+            requests.get("http://127.0.0.1:8002/timers", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.5)
+    else:
+        proc.terminate()
+        proc.wait()
+        raise RuntimeError("API server failed to start")
+    yield
+    proc.terminate()
+    proc.wait()
+
+
+@pytest.mark.asyncio
+async def test_sync_flow(start_server):
+    svc = SyncService("http://127.0.0.1:8002")
+    await svc.connect()
+
+    timer_id = await svc.create_timer(5)
+    # wait for websocket state update
+    for _ in range(10):
+        if str(timer_id) in svc.state:
+            break
+        await asyncio.sleep(0.1)
+    assert str(timer_id) in svc.state
+    assert svc.state[str(timer_id)].remaining == 5
+
+    await svc.tick(2)
+    await asyncio.sleep(0.1)
+    assert svc.state[str(timer_id)].remaining == 3
+
+    await svc.pause_timer(timer_id)
+    await svc.tick(1)
+    await asyncio.sleep(0.1)
+    assert svc.state[str(timer_id)].remaining == 3
+
+    await svc.resume_timer(timer_id)
+    await svc.tick(1)
+    await asyncio.sleep(0.1)
+    assert svc.state[str(timer_id)].remaining == 2
+
+    await svc.remove_timer(timer_id)
+    await asyncio.sleep(0.1)
+    assert str(timer_id) not in svc.state
+
+    await svc.close()


### PR DESCRIPTION
## Summary
- implement `sync_service.py` for client WebSocket sync and REST control
- add `tests/test_sync_service.py` covering end-to-end sync flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685107255ca08330ad1cc52c80fbcabc