### PR TITLE
Implement ClientViewLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | 🌐 APIServer        | Server  | 提供 REST API 和 WebSocket 接口                        | ✅     | TimerManager   | ✅ |
 | 🔔 Notifier         | Server  | 监控倒计时到期状态并执行通知推送                         | ✅     | TimerManager   | ✅ |
 | 👤 ClientAuth       | Server  | 客户端鉴权模块，识别设备ID或Token                       | ✅     | APIServer      | ❌ |
-| 🖼️ ClientViewLayer | Client  | 客户端主界面，显示计时器列表与状态、标签、剩余时间等信息         | ✅     | SyncService    | ❌ |
+| 🖼️ ClientViewLayer | Client  | 客户端主界面，显示计时器列表与状态、标签、剩余时间等信息         | ✅     | SyncService    | ✅ |
 | 🎮 ClientController | Client  | 接收用户操作指令并通过 API 向服务器发送请求                    | ✅     | APIServer      | ❌ |
 | ⚙️ ClientSettings   | Client  | 设置面板：铃声、通知选项、导入导出配置、本地缓存                    | ✅     | 本地数据        | ❌ |
 | 🔁 SyncService      | Client  | 与服务器保持 WebSocket 同步、REST 接口控制                      | ✅     | Server API     | ✅ |

--- a/client_view_layer.py
+++ b/client_view_layer.py
@@ -1,0 +1,91 @@
+"""Client-side view layer displaying timer states using Rich tables."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import List
+
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+
+from sync_service import SyncService, TimerState
+
+
+class ClientViewLayer:
+    """Render timer states provided by :class:`SyncService`."""
+
+    def __init__(self, service: SyncService) -> None:
+        self.service = service
+
+    def _build_table(self) -> Table:
+        table = Table(title="Timer Dashboard")
+        table.add_column("ID", justify="right")
+        table.add_column("Tag")
+        table.add_column("Duration", justify="right")
+        table.add_column("Remaining", justify="right")
+        table.add_column("Status")
+
+        for tid, timer in sorted(self.service.state.items(), key=lambda t: int(t[0])):
+            if timer.finished:
+                status = "finished"
+            else:
+                status = "running" if timer.running else "paused"
+            table.add_row(
+                str(tid),
+                f"Timer {tid}",
+                f"{timer.duration}",
+                f"{timer.remaining}",
+                status,
+            )
+        return table
+
+    async def _fetch_initial_state(self) -> None:
+        resp = await self.service.client.get("/timers")
+        resp.raise_for_status()
+        data = resp.json()
+        self.service.state = {str(tid): TimerState(**info) for tid, info in data.items()}
+
+    async def show_once(self) -> str:
+        """Connect to the server, render one table snapshot and return text."""
+        await self.service.connect()
+        await self._fetch_initial_state()
+        await asyncio.sleep(0.1)
+        console = Console(record=True)
+        console.print(self._build_table())
+        output = console.export_text()
+        await self.service.close()
+        return output
+
+    async def run_live(self) -> None:
+        """Continuously display timer updates until interrupted."""
+        await self.service.connect()
+        await self._fetch_initial_state()
+        console = Console()
+        with Live(self._build_table(), console=console, refresh_per_second=2) as live:
+            try:
+                while True:
+                    live.update(self._build_table())
+                    await asyncio.sleep(0.5)
+            except KeyboardInterrupt:
+                pass
+        await self.service.close()
+
+
+def main(args: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Client view layer")
+    parser.add_argument("--url", default="http://127.0.0.1:8000", help="API base URL")
+    parser.add_argument("--once", action="store_true", help="Render one snapshot and exit")
+    parsed = parser.parse_args(args)
+
+    svc = SyncService(parsed.url)
+    view = ClientViewLayer(svc)
+    if parsed.once:
+        print(asyncio.run(view.show_once()))
+    else:
+        asyncio.run(view.run_live())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_client_view_layer.py
+++ b/tests/test_client_view_layer.py
@@ -1,0 +1,43 @@
+import subprocess
+import sys
+import time
+import requests
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_server():
+    proc = subprocess.Popen([
+        "uvicorn",
+        "api_server:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8003",
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    for _ in range(10):
+        try:
+            requests.get("http://127.0.0.1:8003/timers", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.5)
+    else:
+        proc.terminate()
+        proc.wait()
+        raise RuntimeError("API server failed to start")
+    yield
+    proc.terminate()
+    proc.wait()
+
+
+def test_client_view_once(start_server):
+    resp = requests.post("http://127.0.0.1:8003/timers", params={"duration": 5}, timeout=5)
+    timer_id = resp.json()["timer_id"]
+
+    result = subprocess.run(
+        [sys.executable, "client_view_layer.py", "--once", "--url", "http://127.0.0.1:8003"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert str(timer_id) in result.stdout


### PR DESCRIPTION
## Summary
- add `ClientViewLayer` module to render timers with Rich
- provide CLI entry point with `--once` option
- add tests exercising ClientViewLayer against running API server
- mark ClientViewLayer as completed in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b4eea4f08330896cb05891507a38