### PR TITLE
Add client auth module with tests

### DIFF
--- a/client_auth.py
+++ b/client_auth.py
@@ -1,0 +1,54 @@
+"""Simple token-based client authentication module."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Dict, Optional
+
+from fastapi import Header, HTTPException, status
+
+
+class ClientAuth:
+    """Manage device tokens for authenticating API clients."""
+
+    def __init__(self) -> None:
+        self._tokens: Dict[str, str] = {}
+
+    def register_device(self, token: Optional[str] = None) -> tuple[str, str]:
+        """Register a new device token.
+
+        Parameters
+        ----------
+        token:
+            Optional pre-defined token. If not provided, a random token is
+            generated.
+
+        Returns
+        -------
+        tuple[str, str]
+            The token and associated device ID.
+        """
+        if token is None:
+            token = uuid.uuid4().hex
+        device_id = uuid.uuid4().hex
+        self._tokens[token] = device_id
+        return token, device_id
+
+    def validate(self, token: str) -> Optional[str]:
+        """Return the device_id for ``token`` if valid."""
+        return self._tokens.get(token)
+
+    def remove_token(self, token: str) -> None:
+        """Remove ``token`` from registry if it exists."""
+        self._tokens.pop(token, None)
+
+    async def dependency(self, token: Optional[str] = Header(None, alias="X-Auth-Token")) -> str:
+        """FastAPI dependency to ensure a valid auth token is present."""
+        if token is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                                detail="Missing token")
+        device_id = self.validate(token)
+        if not device_id:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                                detail="Invalid token")
+        return device_id

--- a/tests/test_api_server_httpie.py
+++ b/tests/test_api_server_httpie.py
@@ -36,6 +36,12 @@ def start_server():
 def run_httpie(method, url, *args):
     env = os.environ.copy()
     env["NO_COLOR"] = "1"  # avoid ANSI color codes
+    # Disable update checks which attempt network access
+    temp_dir = os.path.join(os.getcwd(), "httpie_config")
+    os.makedirs(temp_dir, exist_ok=True)
+    with open(os.path.join(temp_dir, "config.json"), "w") as f:
+        json.dump({"disable_update_warnings": True}, f)
+    env["HTTPIE_CONFIG_DIR"] = temp_dir
     cmd = [
         "http",
         "--timeout=5",

--- a/tests/test_client_auth.py
+++ b/tests/test_client_auth.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi import FastAPI, Depends
+from fastapi.testclient import TestClient
+
+from client_auth import ClientAuth
+
+
+def create_app_and_auth():
+    auth = ClientAuth()
+    token, device_id = auth.register_device()
+
+    app = FastAPI()
+
+    @app.get("/protected")
+    async def protected(did: str = Depends(auth.dependency)):
+        return {"device_id": did}
+
+    return app, auth, token, device_id
+
+
+def test_protected_requires_token():
+    app, _, _, _ = create_app_and_auth()
+    client = TestClient(app)
+    resp = client.get("/protected")
+    assert resp.status_code == 401
+
+
+def test_protected_with_valid_token():
+    app, _, token, device_id = create_app_and_auth()
+    client = TestClient(app)
+    resp = client.get("/protected", headers={"X-Auth-Token": token})
+    assert resp.status_code == 200
+    assert resp.json()["device_id"] == device_id
+
+
+def test_protected_with_invalid_token():
+    app, _, token, _ = create_app_and_auth()
+    client = TestClient(app)
+    resp = client.get("/protected", headers={"X-Auth-Token": "bad"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- implement `ClientAuth` for token-based authentication
- add unit tests for `ClientAuth`
- disable HTTPie update checks in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b42b55a88330a2eabdca8dd2530a