### PR TITLE
Implement basic TUIApp and add test

### DIFF
--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,0 +1,43 @@
+import subprocess
+import sys
+import time
+import requests
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_server():
+    proc = subprocess.Popen([
+        "uvicorn",
+        "api_server:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8004",
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    for _ in range(10):
+        try:
+            requests.get("http://127.0.0.1:8004/timers", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.5)
+    else:
+        proc.terminate()
+        proc.wait()
+        raise RuntimeError("API server failed to start")
+    yield
+    proc.terminate()
+    proc.wait()
+
+
+def test_tui_app_once(start_server):
+    resp = requests.post("http://127.0.0.1:8004/timers", params={"duration": 5}, timeout=5)
+    timer_id = resp.json()["timer_id"]
+
+    result = subprocess.run(
+        [sys.executable, "tui_app.py", "--once", "--url", "http://127.0.0.1:8004"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert str(timer_id) in result.stdout

--- a/tui_app.py
+++ b/tui_app.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Terminal UI application for displaying timers.
+
+This module provides a thin wrapper around :class:`ClientViewLayer` to
+initialize the sync service and start rendering timer tables. It only
+implements basic functionality for now: show a single snapshot or run a
+live view that refreshes periodically.
+"""
+
+import argparse
+import asyncio
+from typing import List
+
+from client_view_layer import ClientViewLayer
+from sync_service import SyncService
+
+
+class TUIApp:
+    """Bootstrap the Rich application and manage its lifecycle."""
+
+    def __init__(self, base_url: str) -> None:
+        self.service = SyncService(base_url)
+        self.view = ClientViewLayer(self.service)
+
+    async def run_once(self) -> str:
+        """Render one table snapshot and return its text representation."""
+        return await self.view.show_once()
+
+    async def run(self) -> None:
+        """Run the live view until interrupted."""
+        await self.view.run_live()
+
+
+def main(args: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="MyTimer TUI application")
+    parser.add_argument("--url", default="http://127.0.0.1:8000", help="API base URL")
+    parser.add_argument("--once", action="store_true", help="Render one snapshot and exit")
+    parsed = parser.parse_args(args)
+
+    app = TUIApp(parsed.url)
+    if parsed.once:
+        print(asyncio.run(app.run_once()))
+    else:
+        asyncio.run(app.run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add initial TUIApp module
- provide test for one-off table rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858032397f4833095ba1085639c07e9