### PR TITLE
Add panel view to CLIViewLayer

### DIFF
--- a/tests/test_client_view_layer.py
+++ b/tests/test_client_view_layer.py
@@ -41,3 +41,4 @@ def test_client_view_once(start_server):
     )
     assert result.returncode == 0
     assert str(timer_id) in result.stdout
+    assert "Running:" in result.stdout


### PR DESCRIPTION
## Summary
- enrich `client_view_layer` with a panel summarising timer states
- adjust view layer test to check for panel output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580513725483309e9b753b3b9c83bf