### PR TITLE
Add validation for tick interval

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -88,6 +88,8 @@ async def remove_timer(timer_id: int):
 @app.post("/tick")
 async def tick(seconds: float):
     """Advance all timers by ``seconds``."""
+    if seconds < 0:
+        raise HTTPException(status_code=400, detail="seconds must be non-negative")
     manager.tick(seconds)
     await broadcast_state()
     return {"status": "ticked"}

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -70,3 +70,10 @@ def test_create_timer_invalid_duration():
 def test_pause_invalid_timer():
     resp = client.post('/timers/999/pause')
     assert resp.status_code == 404
+
+
+def test_tick_negative_seconds():
+    client.post('/timers', params={'duration': 5})
+    resp = client.post('/tick', params={'seconds': -1})
+    assert resp.status_code == 400
+    assert resp.json()['detail'] == 'seconds must be non-negative'

--- a/tests/test_timer_manager.py
+++ b/tests/test_timer_manager.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from timer_manager import TimerManager
@@ -62,4 +63,11 @@ def test_create_timer_non_positive_duration():
     neg_timer = tm.timers[tid_neg]
     assert neg_timer.remaining == 0
     assert neg_timer.finished
+
+
+def test_tick_negative_seconds():
+    tm = TimerManager()
+    tm.create_timer(5)
+    with pytest.raises(ValueError):
+        tm.tick(-1)
 

--- a/timer_manager.py
+++ b/timer_manager.py
@@ -22,7 +22,16 @@ class Timer:
             self.finished = True
 
     def tick(self, seconds: float) -> None:
-        """Advance the timer by ``seconds`` if running."""
+        """Advance the timer by ``seconds`` if running.
+
+        Raises
+        ------
+        ValueError
+            If ``seconds`` is negative.
+        """
+        if seconds < 0:
+            raise ValueError("seconds must be non-negative")
+
         if self.running and not self.finished:
             self.remaining -= seconds
             if self.remaining <= 0:
@@ -58,7 +67,15 @@ class TimerManager:
         return timer_id
 
     def tick(self, seconds: float) -> None:
-        """Advance all managed timers."""
+        """Advance all managed timers.
+
+        Raises
+        ------
+        ValueError
+            If ``seconds`` is negative.
+        """
+        if seconds < 0:
+            raise ValueError("seconds must be non-negative")
         for timer in list(self.timers.values()):
             timer.tick(seconds)
 


### PR DESCRIPTION
## Summary
- disallow negative tick values in `TimerManager`
- expose validation error in API server
- test negative tick handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858068210c08330a8a117243dd1500a