### PR TITLE
Add demo script and output for server/client interaction

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,56 @@
+import subprocess
+import requests
+import time
+import sys
+
+SERVER_URL = "http://127.0.0.1:8000"
+
+
+def wait_for_server(url: str, retries: int = 10) -> bool:
+    for _ in range(retries):
+        try:
+            requests.get(url, timeout=1)
+            return True
+        except requests.RequestException:
+            time.sleep(0.5)
+    return False
+
+
+def run_cmd(cmd):
+    print("$", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        print(result.stdout.strip())
+    if result.stderr:
+        print(result.stderr.strip())
+
+
+if __name__ == "__main__":
+    print("Starting server...")
+    server_proc = subprocess.Popen([
+        "uvicorn",
+        "api_server:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8000",
+        "--log-level",
+        "warning",
+    ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    try:
+        if not wait_for_server(f"{SERVER_URL}/timers"):
+            print("Failed to start server")
+            sys.exit(1)
+        print("Server started.\n")
+
+        run_cmd([sys.executable, "client_controller.py", "create", "5"])
+        run_cmd([sys.executable, "client_controller.py", "list"])
+        run_cmd([sys.executable, "client_controller.py", "tick", "3"])
+        run_cmd([sys.executable, "client_controller.py", "list"])
+        run_cmd([sys.executable, "client_controller.py", "remove", "1"])
+        run_cmd([sys.executable, "client_controller.py", "list"])
+    finally:
+        print("\nStopping server...")
+        server_proc.terminate()
+        server_proc.wait()

--- a/demo_output.txt
+++ b/demo_output.txt
@@ -1,0 +1,17 @@
+Starting server...
+Server started.
+
+$ /root/.pyenv/versions/3.12.10/bin/python client_controller.py create 5
+1
+$ /root/.pyenv/versions/3.12.10/bin/python client_controller.py list
+{"1": {"duration": 5.0, "remaining": 5.0, "running": true, "finished": false}}
+$ /root/.pyenv/versions/3.12.10/bin/python client_controller.py tick 3
+ticked
+$ /root/.pyenv/versions/3.12.10/bin/python client_controller.py list
+{"1": {"duration": 5.0, "remaining": 2.0, "running": true, "finished": false}}
+$ /root/.pyenv/versions/3.12.10/bin/python client_controller.py remove 1
+removed
+$ /root/.pyenv/versions/3.12.10/bin/python client_controller.py list
+{}
+
+Stopping server...


### PR DESCRIPTION
## Summary
- add `demo.py` to start the API server and run example client commands
- include `demo_output.txt` with the command-line transcript

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f34f3733c8330ab67c3fa8192a2d1