### PR TITLE
Implement ClientSettings persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | 👤 ClientAuth       | Server  | 客户端鉴权模块，识别设备ID或Token                       | ✅     | APIServer      | ✅ |
 | 🖼️ ClientViewLayer | Client  | 客户端主界面，显示计时器列表与状态、标签、剩余时间等信息         | ✅     | SyncService    | ✅ |
 | 🎮 ClientController | Client  | 接收用户操作指令并通过 API 向服务器发送请求                    | ✅     | APIServer      | ✅ |
-| ⚙️ ClientSettings   | Client  | 设置面板：铃声、通知选项、导入导出配置、本地缓存                    | ✅     | 本地数据        | ❌ |
+| ⚙️ ClientSettings   | Client  | 设置面板：铃声、通知选项、导入导出配置、本地缓存                    | ✅     | 本地数据        | ✅ |
 | 🔁 SyncService      | Client  | 与服务器保持 WebSocket 同步、REST 接口控制                      | ✅     | Server API     | ✅ |
 | 🧭 ServerDiscovery  | Client  | 自动发现局域网服务器，展示服务器连接状态                      | ✅     | 无             | ✅ |
 完成情况说明：✅ 已完成，❌ 未完成

--- a/REARMED.md
+++ b/REARMED.md
@@ -8,9 +8,9 @@
 - Verified that all unit tests pass with `pytest -q`.
 - Implemented `Notifier` for timer completion alerts.
 - Added CLI modules (`tui_app.py`, `client_view_layer.py`, `input_handler.py`).
+- Implemented `ClientSettings` module with configuration persistence.
 
 ## Pending
-- Finish `ClientSettings` module and configuration persistence.
-- Expand integration tests for full client/server workflow.
+ - Expand integration tests for full client/server workflow.
 
 返回 [教程](TUTORIAL.md) 或 [项目概览](README.md)。

--- a/REARMED.zh.md
+++ b/REARMED.zh.md
@@ -8,10 +8,10 @@
 - 通过 `pytest -q` 验证所有单元测试均通过。
 - 实现了计时器结束通知模块 `Notifier`。
 - 新增 CLI 模块（`tui_app.py`、`client_view_layer.py`、`input_handler.py`）。
+- 完成 `ClientSettings` 模块并实现配置持久化。
 
 ## 待办
-- 完成 `ClientSettings` 模块并实现配置持久化。
-- 补充端到端测试以覆盖完整的客户端/服务器工作流程。
+ - 补充端到端测试以覆盖完整的客户端/服务器工作流程.
 
 
 返回 [教程](TUTORIAL.md) 或 [项目概览](README.md)。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,9 @@
 - Verified that all unit tests pass with `pytest -q`.
 - Implemented `Notifier` for timer completion alerts.
 - Added CLI modules (`tui_app.py`, `client_view_layer.py`, `input_handler.py`).
+- Implemented `ClientSettings` module with configuration persistence.
 
 ## Pending
-- Finish `ClientSettings` module and configuration persistence.
-- Expand integration tests for full client/server workflow.
+ - Expand integration tests for full client/server workflow.
 
 返回 [教程](TUTORIAL.md) 或 [项目概览](README.md)。

--- a/ROADMAP.zh.md
+++ b/ROADMAP.zh.md
@@ -8,10 +8,10 @@
 - 通过 `pytest -q` 验证所有单元测试均通过。
 - 实现了计时器结束通知模块 `Notifier`。
 - 新增 CLI 模块（`tui_app.py`、`client_view_layer.py`、`input_handler.py`）。
+- 完成 `ClientSettings` 模块并实现配置持久化。
 
 ## 待办
-- 完成 `ClientSettings` 模块并实现配置持久化。
-- 补充端到端测试以覆盖完整的客户端/服务器工作流程。
+ - 补充端到端测试以覆盖完整的客户端/服务器工作流程。
 
 
 返回 [教程](TUTORIAL.md) 或 [项目概览](README.md)。

--- a/client_settings.py
+++ b/client_settings.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Local configuration handling for MyTimer clients."""
+
+from dataclasses import dataclass, asdict
+import json
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ClientSettings:
+    """Persist and manage client-side configuration."""
+
+    server_url: str = "http://127.0.0.1:8000"
+    notifications_enabled: bool = True
+    notify_sound: str = "default"
+
+    @classmethod
+    def load(cls, path: str | Path) -> "ClientSettings":
+        """Load settings from ``path``. Missing or invalid files return defaults."""
+        file_path = Path(path)
+        if not file_path.exists():
+            return cls()
+        try:
+            with file_path.open("r", encoding="utf-8") as f:
+                data: dict[str, Any] = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return cls()
+
+        return cls(
+            server_url=data.get("server_url", cls.server_url),
+            notifications_enabled=data.get(
+                "notifications_enabled", cls.notifications_enabled
+            ),
+            notify_sound=data.get("notify_sound", cls.notify_sound),
+        )
+
+    def save(self, path: str | Path) -> None:
+        """Write settings to ``path`` as JSON."""
+        file_path = Path(path)
+        with file_path.open("w", encoding="utf-8") as f:
+            json.dump(asdict(self), f)
+
+    def update(self, **kwargs: Any) -> None:
+        """Update attributes with provided keyword arguments."""
+        for field in ("server_url", "notifications_enabled", "notify_sound"):
+            if field in kwargs:
+                setattr(self, field, kwargs[field])

--- a/tests/test_client_settings.py
+++ b/tests/test_client_settings.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import json
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from client_settings import ClientSettings
+
+
+def test_load_defaults_when_file_missing(tmp_path):
+    path = tmp_path / "settings.json"
+    settings = ClientSettings.load(path)
+    assert settings.server_url == "http://127.0.0.1:8000"
+    assert settings.notifications_enabled is True
+    assert settings.notify_sound == "default"
+
+
+def test_save_and_load(tmp_path):
+    path = tmp_path / "settings.json"
+    original = ClientSettings(
+        server_url="http://example.com", notifications_enabled=False, notify_sound="ding"
+    )
+    original.save(path)
+    loaded = ClientSettings.load(path)
+    assert loaded.server_url == "http://example.com"
+    assert loaded.notifications_enabled is False
+    assert loaded.notify_sound == "ding"
+
+
+def test_update_and_persistence(tmp_path):
+    path = tmp_path / "settings.json"
+    settings = ClientSettings()
+    settings.update(server_url="http://server", notify_sound="bell")
+    settings.save(path)
+    loaded = ClientSettings.load(path)
+    assert loaded.server_url == "http://server"
+    assert loaded.notify_sound == "bell"
+    assert loaded.notifications_enabled is True
+
+
+def test_partial_file_uses_defaults(tmp_path):
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"server_url": "http://foo"}))
+    settings = ClientSettings.load(path)
+    assert settings.server_url == "http://foo"
+    assert settings.notifications_enabled is True
+    assert settings.notify_sound == "default"


### PR DESCRIPTION
## Summary
- add `ClientSettings` module with load/save/update helpers
- test `ClientSettings`
- document completion status in README and ROADMAP files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f35abbac88330992ea35d9a289611