### PR TITLE
Add interactive CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@
    uvicorn mytimer.server.api:app --reload
    ```
 3. 启动交互式客户端：
-   ```bash
-   python -m mytimer.client.controller interactive
-   ```
-   或使用图形界面：
-   ```bash
-   python -m mytimer.client.tui_app
-   ```
+```bash
+python -m mytimer.client.controller interactive
+```
+交互界面下输入 `help` 可查看所有命令，`quit` 退出。
+或使用图形界面：
+```bash
+python -m mytimer.client.tui_app
+```
 
 ---
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -63,6 +63,7 @@ python -m tools.server_discovery
 ```bash
 python -m mytimer.client.controller interactive
 ```
+进入交互模式后，可输入 `help` 查看所有支持的命令，使用 `quit` 退出。
 
 图形界面：
 ```bash

--- a/mytimer/client/controller.py
+++ b/mytimer/client/controller.py
@@ -8,10 +8,29 @@ from typing import Any
 
 import requests
 
+HELP_TEXT = """\
+Available commands:
+  create <seconds>  create a new timer
+  list              list all timers
+  pause <id>        pause a timer
+  resume <id>       resume a timer
+  remove <id>       remove a timer
+  tick <seconds>    advance all timers
+  help              show this help message
+  quit/exit         exit the shell
+"""
+
+
+def print_help() -> None:
+    """Print interactive command help."""
+    print(HELP_TEXT)
+
 
 def create_timer(base_url: str, duration: float) -> int:
     """Create a new timer and return its identifier."""
-    resp = requests.post(f"{base_url}/timers", params={"duration": duration}, timeout=5)
+    resp = requests.post(
+        f"{base_url}/timers", params={"duration": duration}, timeout=5
+    )
     resp.raise_for_status()
     timer_id = resp.json()["timer_id"]
     print(timer_id)
@@ -57,6 +76,7 @@ def tick(base_url: str, seconds: float) -> None:
 
 def interactive(base_url: str) -> None:
     """Run an interactive shell for sending timer commands."""
+    print("Type 'help' for available commands. 'quit' to exit.")
     while True:
         try:
             line = input(">> ").strip()
@@ -70,6 +90,9 @@ def interactive(base_url: str) -> None:
         cmd = parts[0]
         args = parts[1:]
         try:
+            if cmd in {"help", "h", "?"}:
+                print_help()
+                continue
             if cmd == "create" and len(args) == 1:
                 create_timer(base_url, float(args[0]))
             elif cmd == "list" and not args:

--- a/mytimer/client/input_handler.py
+++ b/mytimer/client/input_handler.py
@@ -8,6 +8,23 @@ import json
 import sys
 from typing import Optional
 
+HELP_TEXT = """\
+Available commands:
+  create <seconds>  create a new timer
+  list              list all timers
+  pause <id>        pause a timer
+  resume <id>       resume a timer
+  remove <id>       remove a timer
+  tick <seconds>    advance all timers
+  help              show this help message
+  quit/exit/q       exit the shell
+"""
+
+
+def print_help() -> None:
+    """Print interactive command help."""
+    print(HELP_TEXT)
+
 from .sync_service import SyncService
 
 
@@ -29,6 +46,9 @@ class InputHandler:
         try:
             if cmd in {"quit", "exit", "q"}:
                 return False
+            if cmd in {"help", "h", "?"}:
+                print_help()
+                return True
             elif cmd == "create" and len(args) == 1:
                 timer_id = await self.service.create_timer(float(args[0]))
                 print(timer_id)
@@ -57,6 +77,8 @@ class InputHandler:
     async def run(self) -> None:
         """Run the interactive command loop."""
         await self.service.connect()
+        if sys.stdin.isatty():
+            print("Type 'help' for available commands. 'quit' to exit.")
         loop = asyncio.get_running_loop()
         try:
             while True:


### PR DESCRIPTION
## Summary
- add inline help for interactive CLI commands in `controller.py` and `input_handler.py`
- show usage hints for interactive shells
- document the `help` command in README and TUTORIAL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f8de535e08330a6cd02fdc815ae50