### PR TITLE
Fix interactive mode output for tests

### DIFF
--- a/mytimer/client/controller.py
+++ b/mytimer/client/controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from typing import Any
 
 import requests
@@ -76,7 +77,8 @@ def tick(base_url: str, seconds: float) -> None:
 
 def interactive(base_url: str) -> None:
     """Run an interactive shell for sending timer commands."""
-    print("Type 'help' for available commands. 'quit' to exit.")
+    if sys.stdin.isatty():
+        print("Type 'help' for available commands. 'quit' to exit.")
     while True:
         try:
             line = input(">> ").strip()


### PR DESCRIPTION
## Summary
- only show the interactive help message when stdin is a TTY
- add missing `sys` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d310f5a08330bbd3a76aa1cccfe4