### PR TITLE
Improve tests for interactive CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+httpie_config/

--- a/tests/test_client_controller_interactive_flow.py
+++ b/tests/test_client_controller_interactive_flow.py
@@ -53,6 +53,8 @@ def test_interactive_flow(start_server):
     stdout, stderr = proc.communicate(cmds, timeout=15)
     assert proc.returncode == 0, stderr
     lines = [l.replace(">> ", "").strip() for l in stdout.splitlines() if l.strip() and l.strip() != ">>"]
+    if lines[0].startswith("Type 'help'"):
+        lines = lines[1:]
     timer_id = int(lines[0])
     state = json.loads(lines[5])
     assert str(timer_id) in state

--- a/tests/test_controller_help.py
+++ b/tests/test_controller_help.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+
+
+def test_help_command():
+    proc = subprocess.Popen(
+        [sys.executable, '-m', 'mytimer.client.controller', 'interactive'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = proc.communicate('help\nquit\n', timeout=5)
+    assert proc.returncode == 0, stderr
+    assert 'Available commands:' in stdout


### PR DESCRIPTION
## Summary
- fix parsing for controller interactive flow
- add new test covering `help` command
- ignore httpie config directory

## Testing
- `pytest -q`
- `python -m mytimer.client.controller --url http://127.0.0.1:8001 interactive <<'EOF'
create 5
list
pause 1
resume 1
tick 2
list
quit
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_6860d24280b88330a45b9f7eb3f5446a