### PR TITLE
Improve client error handling

### DIFF
--- a/tests/test_client_controller_server_unavailable.py
+++ b/tests/test_client_controller_server_unavailable.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+
+
+def test_server_unavailable(tmp_path):
+    result = subprocess.run([
+        sys.executable,
+        '-m', 'mytimer.client.controller',
+        '--url', 'http://127.0.0.1:9999',
+        'list'
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'Failed to contact server' in result.stdout


### PR DESCRIPTION
## Summary
- handle connection errors in client controller
- print helpful message when server can't be reached
- test client behavior when server is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860d56f09b48330842fc746f24e28bc