### PR TITLE
Add CLI management script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,17 @@
 
 ## 🚀 快速开始
 
-1. 安装依赖并运行测试：
+1. 安装依赖并运行测试（也可以使用下方的管理脚本）：
    ```bash
    pip install -r requirements.txt
    pytest -q
    ```
-2. 启动服务器：
+   或执行
+   ```bash
+   python tools/manage.py install
+   python tools/manage.py test
+   ```
+2. 启动服务器（或使用 `python tools/manage.py start`）：
    ```bash
    uvicorn mytimer.server.api:app --reload
    ```

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -10,11 +10,11 @@
 
 ## 环境准备
 
-1. 安装依赖：
+1. 安装依赖（或使用 `python tools/manage.py install`）：
    ```bash
    pip install -r requirements.txt
    ```
-2. 运行单元测试确保环境正常：
+2. 运行单元测试确保环境正常（或使用 `python tools/manage.py test`）：
    ```bash
    pytest -q
    ```
@@ -26,8 +26,12 @@
 ```bash
 uvicorn mytimer.server.api:app --reload
 ```
+或执行
+```bash
+python tools/manage.py start
+```
 
-默认情况下，服务监听在 `http://127.0.0.1:8000`。您可以使用 `curl` 或任何支持 HTTP 的工具与之交互。
+默认情况下，服务监听在 `http://127.0.0.1:8000`。若要关闭服务器，可以运行 `python tools/manage.py stop`。您可以使用 `curl` 或任何支持 HTTP 的工具与之交互。
 
 ### 创建计时器
 

--- a/tools/manage.py
+++ b/tools/manage.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Utility for managing MyTimer operations from the command line."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+PID_FILE = Path("server.pid")
+
+
+def run_install() -> None:
+    """Install dependencies listed in requirements.txt using pip."""
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+
+
+def run_tests() -> None:
+    """Run the project's test suite using pytest."""
+    subprocess.check_call(["pytest", "-q"])
+
+
+def start_server(port: int) -> None:
+    """Start the API server with uvicorn and save the PID."""
+    if PID_FILE.exists():
+        print("Server already running")
+        return
+    proc = subprocess.Popen([
+        "uvicorn",
+        "mytimer.server.api:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(port),
+    ])
+    PID_FILE.write_text(str(proc.pid))
+    print(f"Server started on port {port} (PID {proc.pid})")
+
+
+def stop_server() -> None:
+    """Terminate the running API server."""
+    if not PID_FILE.exists():
+        print("Server not running")
+        return
+    pid = int(PID_FILE.read_text())
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    PID_FILE.unlink()
+    print("Server stopped")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MyTimer management tool")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("install", help="Install project dependencies")
+
+    start_p = sub.add_parser("start", help="Start the API server")
+    start_p.add_argument("--port", type=int, default=8000, help="Server port")
+
+    sub.add_parser("stop", help="Stop the running API server")
+
+    sub.add_parser("test", help="Run all unit tests")
+
+    args = parser.parse_args()
+
+    if args.command == "install":
+        run_install()
+    elif args.command == "start":
+        start_server(args.port)
+    elif args.command == "stop":
+        stop_server()
+    elif args.command == "test":
+        run_tests()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/manage.py` to run installs, tests, and the API server
- document how to use `manage.py` in README and TUTORIAL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d5ce552c8330916de432daa8569e