### PR TITLE
Fix httpie compatibility with urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ httpx
 requests
 pytest
 pytest-asyncio
-httpie
+httpie>=3.2.2
 rich
 psutil
 websockets


### PR DESCRIPTION
## Summary
- pin httpie to a version compatible with urllib3 >=2

## Testing
- `python tools/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6863740292448330b85c9a73a428dcf3