### PR TITLE
Add CLI and TUI launch commands to manage tool

### DIFF
--- a/tools/manage.py
+++ b/tools/manage.py
@@ -4,11 +4,16 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import os
 import signal
 import subprocess
 import sys
 from pathlib import Path
+
+import requests
+
+from tools import server_discovery
 
 PID_FILE = Path("server.pid")
 
@@ -54,6 +59,46 @@ def stop_server() -> None:
     print("Server stopped")
 
 
+def ensure_server(url: str) -> str | None:
+    """Return a reachable server URL or ``None`` if unavailable."""
+    base = url.rstrip("/")
+    try:
+        requests.get(f"{base}/timers", timeout=1)
+        return base
+    except requests.RequestException:
+        print(f"Server not reachable at {base}. Searching for servers...")
+    try:
+        servers = asyncio.run(server_discovery.discover_server())
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        print(f"Discovery failed: {exc}")
+        servers = []
+    if servers:
+        found = f"http://{servers[0]}:8000"
+        print(f"Using discovered server {found}")
+        return found
+    print("No server found. Use 'python tools/manage.py start' to launch one.")
+    return None
+
+
+def run_controller(url: str, controller_args: list[str]) -> None:
+    """Run the CLI controller if a server is available."""
+    server = ensure_server(url)
+    if not server:
+        return
+    subprocess.call([sys.executable, "-m", "mytimer.client.controller", "--url", server, *controller_args])
+
+
+def run_tui(url: str, once: bool) -> None:
+    """Run the TUI application if a server is available."""
+    server = ensure_server(url)
+    if not server:
+        return
+    cmd = [sys.executable, "-m", "mytimer.client.tui_app", "--url", server]
+    if once:
+        cmd.append("--once")
+    subprocess.call(cmd)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="MyTimer management tool")
     sub = parser.add_subparsers(dest="command")
@@ -67,6 +112,14 @@ def main() -> None:
 
     sub.add_parser("test", help="Run all unit tests")
 
+    cli_p = sub.add_parser("cli", help="Run the CLI client")
+    cli_p.add_argument("client_args", nargs=argparse.REMAINDER, help="Arguments for the client controller")
+    cli_p.add_argument("--url", default="http://127.0.0.1:8000", help="Server base URL")
+
+    tui_p = sub.add_parser("tui", help="Run the TUI client")
+    tui_p.add_argument("--url", default="http://127.0.0.1:8000", help="Server base URL")
+    tui_p.add_argument("--once", action="store_true", help="Render one snapshot and exit")
+
     args = parser.parse_args()
 
     if args.command == "install":
@@ -77,6 +130,10 @@ def main() -> None:
         stop_server()
     elif args.command == "test":
         run_tests()
+    elif args.command == "cli":
+        run_controller(args.url, args.client_args)
+    elif args.command == "tui":
+        run_tui(args.url, args.once)
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- extend `tools/manage.py` with client launcher commands
- automatically check for a running server when starting clients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686374476ad8833084150cd4c3a66351