### PR TITLE
Add UDP discovery server

### DIFF
--- a/mytimer/server/api.py
+++ b/mytimer/server/api.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from typing import List
 
 from ..core.timer_manager import TimerManager
+from .discovery import create_discovery_server
 
 app = FastAPI()
 
@@ -15,6 +16,7 @@ manager = TimerManager()
 
 # store connected websockets
 websockets: List[WebSocket] = []
+discovery = create_discovery_server()
 
 async def broadcast_state() -> None:
     """Send the current timer state to all connected WebSocket clients."""
@@ -104,3 +106,13 @@ async def websocket_endpoint(ws: WebSocket):
             await ws.receive_text()
     except WebSocketDisconnect:
         websockets.remove(ws)
+
+
+@app.on_event("startup")
+async def _start_discovery() -> None:
+    await discovery.start()
+
+
+@app.on_event("shutdown")
+async def _stop_discovery() -> None:
+    await discovery.stop()

--- a/mytimer/server/discovery.py
+++ b/mytimer/server/discovery.py
@@ -1,0 +1,66 @@
+"""UDP discovery server used to locate the API on local networks."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+
+BROADCAST_PORT = 9999
+DISCOVERY_MESSAGE = b"DISCOVER_SERVER"
+RESPONSE_MESSAGE = b"SERVER_HERE"
+
+
+class DiscoveryServer:
+    """Listen for discovery broadcasts and respond with server details."""
+
+    def __init__(self, api_port: int, udp_port: int = BROADCAST_PORT) -> None:
+        self.api_port = api_port
+        self.udp_port = udp_port
+        self._sock: socket.socket | None = None
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start listening for discovery messages."""
+        if self._task:
+            return
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setblocking(False)
+        try:
+            sock.bind(("", self.udp_port))
+        except OSError:
+            sock.close()
+            return
+        self._sock = sock
+        self._task = asyncio.create_task(self._serve())
+
+    async def stop(self) -> None:
+        """Stop the discovery service."""
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        if self._sock:
+            self._sock.close()
+        self._task = None
+        self._sock = None
+
+    async def _serve(self) -> None:
+        assert self._sock is not None
+        loop = asyncio.get_running_loop()
+        while True:
+            try:
+                data, addr = await loop.sock_recvfrom(self._sock, 1024)
+            except asyncio.CancelledError:
+                break
+            if data.startswith(DISCOVERY_MESSAGE):
+                msg = RESPONSE_MESSAGE + b" " + str(self.api_port).encode()
+                await loop.sock_sendto(self._sock, msg, addr)
+
+
+def create_discovery_server() -> DiscoveryServer:
+    """Factory reading environment variables for configuration."""
+    port = int(os.environ.get("MYTIMER_API_PORT", "8000"))
+    return DiscoveryServer(api_port=port)

--- a/tools/manage.py
+++ b/tools/manage.py
@@ -28,6 +28,8 @@ def start_server(port: int) -> None:
     if PID_FILE.exists():
         print("Server already running")
         return
+    env = os.environ.copy()
+    env["MYTIMER_API_PORT"] = str(port)
     proc = subprocess.Popen([
         "uvicorn",
         "mytimer.server.api:app",
@@ -35,7 +37,7 @@ def start_server(port: int) -> None:
         "0.0.0.0",
         "--port",
         str(port),
-    ])
+    ], env=env)
     PID_FILE.write_text(str(proc.pid))
     print(f"Server started on port {port} (PID {proc.pid})")
 


### PR DESCRIPTION
## Summary
- implement a discovery server for UDP broadcasts
- start/stop discovery service automatically in API startup/shutdown events
- expose server port through the discovery reply and show it in the client
- pass the server port via environment variable in `manage.py`

## Testing
- `pytest -q`
- `python tools/manage.py start --port 8001`
- `python -m tools.server_discovery --timeout 1 --port 9999`
- `python tools/manage.py stop`


------
https://chatgpt.com/codex/tasks/task_e_686374ffabf08330991ce10c82cbaeda