### PR TITLE
Fix manage.py path for package imports

### DIFF
--- a/tools/manage.py
+++ b/tools/manage.py
@@ -11,6 +11,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Ensure the repository root is on ``sys.path`` so imports work when executing
+# this script directly from the command line.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
 import requests
 
 from tools import server_discovery


### PR DESCRIPTION
## Summary
- ensure repository root is added to `sys.path` before importing project packages
- make `tools` a package so `tools.server_discovery` can be imported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68637734ca7c8330ba08bfa8cd641104