### PR TITLE
Add websocket manager and CLI notifications

### DIFF
--- a/mytimer/server/websocket_manager.py
+++ b/mytimer/server/websocket_manager.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Utility class to manage WebSocket connections and broadcast messages."""
+
+
+from typing import Set, Any
+from fastapi import WebSocket, WebSocketDisconnect
+
+class WebSocketManager:
+    """Manage connected WebSocket clients."""
+
+    def __init__(self) -> None:
+        self._websockets: Set[WebSocket] = set()
+
+    async def connect(self, ws: WebSocket) -> None:
+        """Accept and register a new WebSocket connection."""
+        await ws.accept()
+        self._websockets.add(ws)
+
+    def disconnect(self, ws: WebSocket) -> None:
+        """Remove a WebSocket from the registry."""
+        self._websockets.discard(ws)
+
+    async def broadcast_json(self, data: Any) -> None:
+        """Send ``data`` to all connected clients as JSON."""
+        for ws in list(self._websockets):
+            try:
+                await ws.send_json(data)
+            except WebSocketDisconnect:
+                self._websockets.discard(ws)
+
+    async def broadcast_text(self, message: str) -> None:
+        """Send a plain text ``message`` to all connected clients."""
+        for ws in list(self._websockets):
+            try:
+                await ws.send_text(message)
+            except WebSocketDisconnect:
+                self._websockets.discard(ws)

--- a/tools/manage.py
+++ b/tools/manage.py
@@ -9,6 +9,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 # Ensure the repository root is on ``sys.path`` so imports work when executing
@@ -135,6 +136,24 @@ def run_tui(url: str, once: bool) -> None:
     subprocess.call(cmd)
 
 
+def run_auto_tick(url: str, interval: float) -> None:
+    """Continuously tick the server until interrupted."""
+    server = ensure_server(url)
+    if not server:
+        return
+    print(f"Auto ticking every {interval} seconds. Press Ctrl+C to stop.")
+    try:
+        while True:
+            try:
+                requests.post(f"{server}/tick", params={"seconds": interval}, timeout=5)
+            except requests.RequestException:
+                print("Tick failed")
+                break
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        pass
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="MyTimer management tool")
     sub = parser.add_subparsers(dest="command")
@@ -151,6 +170,10 @@ def main() -> None:
     sub.add_parser("log", help="Show the API server log output")
 
     sub.add_parser("test", help="Run all unit tests")
+
+    auto_p = sub.add_parser("autotick", help="Automatically tick the server")
+    auto_p.add_argument("--url", default="http://127.0.0.1:8000", help="Server base URL")
+    auto_p.add_argument("--interval", type=float, default=1.0, help="Tick interval in seconds")
 
     cli_p = sub.add_parser("cli", help="Run the CLI client")
     cli_p.add_argument("client_args", nargs=argparse.REMAINDER, help="Arguments for the client controller")
@@ -178,6 +201,8 @@ def main() -> None:
         run_controller(args.url, args.client_args)
     elif args.command == "tui":
         run_tui(args.url, args.once)
+    elif args.command == "autotick":
+        run_auto_tick(args.url, args.interval)
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- add `WebSocketManager` to manage connections
- extend `TimerManager` with callback system
- broadcast timer updates on tick and finish
- add audible notification support to CLI tools
- support auto tick mode via manage.py

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68637db319988330b279e222fc76316c