### PR TITLE
Implement WebSocket initial state broadcast

### DIFF
--- a/mytimer/server/api.py
+++ b/mytimer/server/api.py
@@ -126,6 +126,20 @@ async def tick(seconds: float):
 async def websocket_endpoint(ws: WebSocket):
     """WebSocket endpoint for real-time timer updates."""
     await ws_manager.connect(ws)
+    # send current timer state immediately after connection if any timers exist
+    if manager.timers:
+        await ws_manager.send_json(
+            ws,
+            {
+                timer_id: {
+                    "duration": timer.duration,
+                    "remaining": timer.remaining,
+                    "running": timer.running,
+                    "finished": timer.finished,
+                }
+                for timer_id, timer in manager.timers.items()
+            },
+        )
     try:
         while True:
             await ws.receive_text()

--- a/mytimer/server/websocket_manager.py
+++ b/mytimer/server/websocket_manager.py
@@ -29,6 +29,13 @@ class WebSocketManager:
             except WebSocketDisconnect:
                 self._websockets.discard(ws)
 
+    async def send_json(self, ws: WebSocket, data: Any) -> None:
+        """Send ``data`` to a single ``ws`` connection as JSON."""
+        try:
+            await ws.send_json(data)
+        except WebSocketDisconnect:
+            self._websockets.discard(ws)
+
     async def broadcast_text(self, message: str) -> None:
         """Send a plain text ``message`` to all connected clients."""
         for ws in list(self._websockets):
@@ -36,3 +43,10 @@ class WebSocketManager:
                 await ws.send_text(message)
             except WebSocketDisconnect:
                 self._websockets.discard(ws)
+
+    async def send_text(self, ws: WebSocket, message: str) -> None:
+        """Send a plain text ``message`` to a single ``ws`` connection."""
+        try:
+            await ws.send_text(message)
+        except WebSocketDisconnect:
+            self._websockets.discard(ws)


### PR DESCRIPTION
## Summary
- extend `WebSocketManager` with `send_json`/`send_text`
- send current timer state to a new WebSocket connection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867cd52357083309f1288b37452a7d5