### PR TITLE
Implement CLISettings and theme persistence

### DIFF
--- a/client_settings.py
+++ b/client_settings.py
@@ -15,6 +15,7 @@ class ClientSettings:
     server_url: str = "http://127.0.0.1:8000"
     notifications_enabled: bool = True
     notify_sound: str = "default"
+    theme: str = "light"
 
     @classmethod
     def load(cls, path: str | Path) -> "ClientSettings":
@@ -34,6 +35,7 @@ class ClientSettings:
                 "notifications_enabled", cls.notifications_enabled
             ),
             notify_sound=data.get("notify_sound", cls.notify_sound),
+            theme=data.get("theme", cls.theme),
         )
 
     def save(self, path: str | Path) -> None:
@@ -44,6 +46,6 @@ class ClientSettings:
 
     def update(self, **kwargs: Any) -> None:
         """Update attributes with provided keyword arguments."""
-        for field in ("server_url", "notifications_enabled", "notify_sound"):
+        for field in ("server_url", "notifications_enabled", "notify_sound", "theme"):
             if field in kwargs:
                 setattr(self, field, kwargs[field])

--- a/mytimer/client/cli_settings.py
+++ b/mytimer/client/cli_settings.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+"""Interactive CLI tool for editing MyTimer settings."""
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from client_settings import ClientSettings
+
+SETTINGS_PATH = Path.home() / ".timercli" / "settings.json"
+
+
+class CLISettings:
+    """Terminal menu for updating :class:`ClientSettings`."""
+
+    def __init__(self, path: Path = SETTINGS_PATH) -> None:
+        self.path = path
+        self.settings = ClientSettings.load(self.path)
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.settings.save(self.path)
+
+    def _prompt(self, prompt: str, iterator: Iterable[str] | None) -> str:
+        if iterator is not None:
+            try:
+                return next(iterator).strip()
+            except StopIteration:
+                return ""
+        return input(prompt).strip()
+
+    def run_interactive(self, commands: Iterable[str] | None = None) -> None:
+        it = iter(commands) if commands is not None else None
+        while True:
+            print(
+                f"\nSettings file: {self.path}\n"
+                f"1. Server URL: {self.settings.server_url}\n"
+                f"2. Theme: {self.settings.theme}\n"
+                f"3. Notifications Enabled: {self.settings.notifications_enabled}\n"
+                f"4. Notify Sound: {self.settings.notify_sound}\n"
+                "5. Save and exit\n"
+                "q. Quit\n"
+                "Choice: ",
+                end="",
+            )
+            choice = self._prompt("", it)
+            if choice == "1":
+                value = self._prompt("Server URL: ", it)
+                if value:
+                    self.settings.server_url = value
+            elif choice == "2":
+                value = self._prompt("Theme: ", it)
+                if value:
+                    self.settings.theme = value
+            elif choice == "3":
+                value = self._prompt("Enable notifications (y/n): ", it).lower()
+                if value in {"y", "yes"}:
+                    self.settings.notifications_enabled = True
+                elif value in {"n", "no"}:
+                    self.settings.notifications_enabled = False
+            elif choice == "4":
+                value = self._prompt("Notify sound: ", it)
+                if value:
+                    self.settings.notify_sound = value
+            elif choice == "5":
+                self.save()
+                print("Saved.")
+                break
+            elif choice.lower() in {"q", "quit", "exit"}:
+                break
+            else:
+                print("Invalid choice")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Manage MyTimer CLI settings")
+    parser.add_argument("--path", help="Settings file path")
+    parser.add_argument("--server-url", help="API server URL")
+    parser.add_argument("--theme", help="Color theme name")
+    parser.add_argument("--enable-notify", action="store_true", help="Enable notifications")
+    parser.add_argument("--disable-notify", action="store_true", help="Disable notifications")
+    parser.add_argument("--notify-sound", help="Notification sound")
+    parser.add_argument("--print", action="store_true", help="Print current settings")
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.path) if args.path else SETTINGS_PATH
+    cli = CLISettings(config_path)
+    changed = False
+    if args.server_url:
+        cli.settings.server_url = args.server_url
+        changed = True
+    if args.theme:
+        cli.settings.theme = args.theme
+        changed = True
+    if args.enable_notify:
+        cli.settings.notifications_enabled = True
+        changed = True
+    if args.disable_notify:
+        cli.settings.notifications_enabled = False
+        changed = True
+    if args.notify_sound:
+        cli.settings.notify_sound = args.notify_sound
+        changed = True
+
+    if args.print and not changed:
+        print(cli.settings)
+        return
+
+    if changed:
+        cli.save()
+    else:
+        cli.run_interactive()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_cli_settings_module.py
+++ b/tests/test_cli_settings_module.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("inputs,expected", [
+    ("1\nhttp://example.com\n2\ndark\n5\n", {"server_url": "http://example.com", "theme": "dark"}),
+])
+def test_cli_settings_interactive(tmp_path, monkeypatch, inputs, expected):
+    config_dir = tmp_path / ".timercli"
+    config_dir.mkdir()
+    settings_file = config_dir / "settings.json"
+    settings_file.write_text("{}")
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "mytimer.client.cli_settings", "--path", str(settings_file)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    proc.communicate(inputs, timeout=5)
+    assert proc.returncode == 0
+    data = json.loads(settings_file.read_text())
+    for key, value in expected.items():
+        assert data[key] == value

--- a/tests/test_client_settings.py
+++ b/tests/test_client_settings.py
@@ -13,28 +13,34 @@ def test_load_defaults_when_file_missing(tmp_path):
     assert settings.server_url == "http://127.0.0.1:8000"
     assert settings.notifications_enabled is True
     assert settings.notify_sound == "default"
+    assert settings.theme == "light"
 
 
 def test_save_and_load(tmp_path):
     path = tmp_path / "settings.json"
     original = ClientSettings(
-        server_url="http://example.com", notifications_enabled=False, notify_sound="ding"
+        server_url="http://example.com",
+        notifications_enabled=False,
+        notify_sound="ding",
+        theme="dark",
     )
     original.save(path)
     loaded = ClientSettings.load(path)
     assert loaded.server_url == "http://example.com"
     assert loaded.notifications_enabled is False
     assert loaded.notify_sound == "ding"
+    assert loaded.theme == "dark"
 
 
 def test_update_and_persistence(tmp_path):
     path = tmp_path / "settings.json"
     settings = ClientSettings()
-    settings.update(server_url="http://server", notify_sound="bell")
+    settings.update(server_url="http://server", notify_sound="bell", theme="blue")
     settings.save(path)
     loaded = ClientSettings.load(path)
     assert loaded.server_url == "http://server"
     assert loaded.notify_sound == "bell"
+    assert loaded.theme == "blue"
     assert loaded.notifications_enabled is True
 
 
@@ -45,3 +51,4 @@ def test_partial_file_uses_defaults(tmp_path):
     assert settings.server_url == "http://foo"
     assert settings.notifications_enabled is True
     assert settings.notify_sound == "default"
+    assert settings.theme == "light"


### PR DESCRIPTION
## Summary
- extend `ClientSettings` with a `theme` field
- add new interactive `CLISettings` module for editing settings
- update client settings tests for theme
- add tests for CLISettings interactive workflow

## Testing
- `pytest tests/test_cli_settings_module.py::test_cli_settings_interactive -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbad2aeb883308b19c4276cbd18e1