### PR TITLE
Implement config import/export with device info

### DIFF
--- a/client_settings.py
+++ b/client_settings.py
@@ -15,6 +15,8 @@ class ClientSettings:
     server_url: str = "http://127.0.0.1:8000"
     notifications_enabled: bool = True
     notify_sound: str = "default"
+    auth_token: str | None = None
+    device_name: str | None = None
 
     @classmethod
     def load(cls, path: str | Path) -> "ClientSettings":
@@ -34,6 +36,8 @@ class ClientSettings:
                 "notifications_enabled", cls.notifications_enabled
             ),
             notify_sound=data.get("notify_sound", cls.notify_sound),
+            auth_token=data.get("auth_token"),
+            device_name=data.get("device_name"),
         )
 
     def save(self, path: str | Path) -> None:
@@ -44,6 +48,22 @@ class ClientSettings:
 
     def update(self, **kwargs: Any) -> None:
         """Update attributes with provided keyword arguments."""
-        for field in ("server_url", "notifications_enabled", "notify_sound"):
+        for field in (
+            "server_url",
+            "notifications_enabled",
+            "notify_sound",
+            "auth_token",
+            "device_name",
+        ):
             if field in kwargs:
                 setattr(self, field, kwargs[field])
+
+    def export_json(self, path: str | Path) -> None:
+        """Export settings to ``path`` as JSON."""
+        self.save(path)
+
+    @classmethod
+    def import_json(cls, path: str | Path) -> "ClientSettings":
+        """Load settings from ``path`` using :meth:`load`."""
+        return cls.load(path)
+

--- a/tests/test_client_settings.py
+++ b/tests/test_client_settings.py
@@ -13,29 +13,44 @@ def test_load_defaults_when_file_missing(tmp_path):
     assert settings.server_url == "http://127.0.0.1:8000"
     assert settings.notifications_enabled is True
     assert settings.notify_sound == "default"
+    assert settings.auth_token is None
+    assert settings.device_name is None
 
 
 def test_save_and_load(tmp_path):
     path = tmp_path / "settings.json"
     original = ClientSettings(
-        server_url="http://example.com", notifications_enabled=False, notify_sound="ding"
+        server_url="http://example.com",
+        notifications_enabled=False,
+        notify_sound="ding",
+        auth_token="abc",
+        device_name="dev1",
     )
     original.save(path)
     loaded = ClientSettings.load(path)
     assert loaded.server_url == "http://example.com"
     assert loaded.notifications_enabled is False
     assert loaded.notify_sound == "ding"
+    assert loaded.auth_token == "abc"
+    assert loaded.device_name == "dev1"
 
 
 def test_update_and_persistence(tmp_path):
     path = tmp_path / "settings.json"
     settings = ClientSettings()
-    settings.update(server_url="http://server", notify_sound="bell")
+    settings.update(
+        server_url="http://server",
+        notify_sound="bell",
+        auth_token="xyz",
+        device_name="dev2",
+    )
     settings.save(path)
     loaded = ClientSettings.load(path)
     assert loaded.server_url == "http://server"
     assert loaded.notify_sound == "bell"
     assert loaded.notifications_enabled is True
+    assert loaded.auth_token == "xyz"
+    assert loaded.device_name == "dev2"
 
 
 def test_partial_file_uses_defaults(tmp_path):
@@ -45,3 +60,24 @@ def test_partial_file_uses_defaults(tmp_path):
     assert settings.server_url == "http://foo"
     assert settings.notifications_enabled is True
     assert settings.notify_sound == "default"
+    assert settings.auth_token is None
+    assert settings.device_name is None
+
+
+def test_import_export_json(tmp_path):
+    path = tmp_path / "settings.json"
+    settings = ClientSettings(
+        server_url="http://s",
+        notifications_enabled=False,
+        notify_sound="ding",
+        auth_token="tok",
+        device_name="name",
+    )
+    settings.export_json(path)
+    loaded = ClientSettings.import_json(path)
+    assert loaded.server_url == "http://s"
+    assert loaded.notifications_enabled is False
+    assert loaded.notify_sound == "ding"
+    assert loaded.auth_token == "tok"
+    assert loaded.device_name == "name"
+


### PR DESCRIPTION
## Summary
- expand `ClientSettings` to include `auth_token` and `device_name`
- support import and export of settings as JSON
- test new configuration fields and import/export helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbc409e088330ae5039f9a7a783c6