### PR TITLE
Fix ClientSettings dataclass and tests

### DIFF
--- a/client_settings.py
+++ b/client_settings.py
@@ -15,6 +15,9 @@ class ClientSettings:
     server_url: str = "http://127.0.0.1:8000"
     notifications_enabled: bool = True
     notify_sound: str = "default"
+    theme: str = "light"
+    volume: float = 1.0
+    mute: bool = False
 
     @classmethod
     def load(cls, path: str | Path) -> "ClientSettings":
@@ -34,6 +37,9 @@ class ClientSettings:
                 "notifications_enabled", cls.notifications_enabled
             ),
             notify_sound=data.get("notify_sound", cls.notify_sound),
+            theme=data.get("theme", cls.theme),
+            volume=float(data.get("volume", cls.volume)),
+            mute=bool(data.get("mute", cls.mute)),
         )
 
     def save(self, path: str | Path) -> None:
@@ -44,6 +50,13 @@ class ClientSettings:
 
     def update(self, **kwargs: Any) -> None:
         """Update attributes with provided keyword arguments."""
-        for field in ("server_url", "notifications_enabled", "notify_sound"):
+        for field in (
+            "server_url",
+            "notifications_enabled",
+            "notify_sound",
+            "theme",
+            "volume",
+            "mute",
+        ):
             if field in kwargs:
                 setattr(self, field, kwargs[field])

--- a/tests/test_client_settings.py
+++ b/tests/test_client_settings.py
@@ -26,7 +26,7 @@ def test_save_and_load(tmp_path):
         notifications_enabled=False,
        
         notify_sound="ding",
-        theme="dark",,
+        theme="dark",
         volume=0.5,
         mute=True,
     )


### PR DESCRIPTION
## Summary
- add `theme`, `volume`, and `mute` fields to `ClientSettings`
- load and update new fields and adjust defaults
- update unit test for ClientSettings
- ensure all tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc0b247fc83308d4a94ab6ae6c8d5