### PR TITLE
Fix tick command usage message

### DIFF
--- a/mytimer/client/controller.py
+++ b/mytimer/client/controller.py
@@ -204,8 +204,11 @@ def interactive(base_url: str) -> None:
                 remove_timer(base_url, int(args[0]))
             elif cmd in {"clear", "reset"} and not args:
                 clear_timers(base_url)
-            elif cmd == "tick" and len(args) == 1:
-                tick(base_url, float(args[0]))
+            elif cmd == "tick":
+                if len(args) == 1:
+                    tick(base_url, float(args[0]))
+                else:
+                    print("Usage: tick <seconds>")
             else:
                 suggestion = suggest_command(cmd)
                 if suggestion:
@@ -250,8 +253,11 @@ def main() -> None:
             remove_timer(base_url, int(parsed.args[0]))
         elif parsed.command in {"clear", "reset"}:
             clear_timers(base_url)
-        elif parsed.command == "tick" and len(parsed.args) == 1:
-            tick(base_url, float(parsed.args[0]))
+        elif parsed.command == "tick":
+            if len(parsed.args) == 1:
+                tick(base_url, float(parsed.args[0]))
+            else:
+                print("Usage: tick <seconds>")
         elif parsed.command == "interactive" or parsed.command is None:
             interactive(base_url)
         else:

--- a/tests/test_client_controller.py
+++ b/tests/test_client_controller.py
@@ -101,3 +101,8 @@ def test_cli_all_commands(start_server):
 def test_cli_suggestion(start_server):
     out = run_cli("creat")  # misspelled create
     assert "Did you mean 'create'" in out
+
+
+def test_tick_no_args_usage(start_server):
+    out = run_cli("tick")
+    assert "Usage: tick <seconds>" in out


### PR DESCRIPTION
## Summary
- improve controller's `tick` command to show usage when no args
- add regression test for CLI tick usage output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f4cc4518c83308099c33ceb096653