### PR TITLE
Implement TUI auto refresh

### DIFF
--- a/mytimer/client/view_layer.py
+++ b/mytimer/client/view_layer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import os
 import sys
 from pathlib import Path
 from typing import List
@@ -129,8 +130,18 @@ class ClientViewLayer:
                     if tid is not None:
                         await self.service.remove_timer(int(tid))
 
+        async def tick_loop() -> None:
+            nonlocal running
+            while running:
+                try:
+                    await self.service.tick(1.0)
+                except Exception:
+                    pass
+                await asyncio.sleep(1.0)
+
         with Live(self._build_panel(), console=console, refresh_per_second=2) as live:
             task = asyncio.create_task(input_loop())
+            tick_task = asyncio.create_task(tick_loop())
             try:
                 while running:
                     live.update(self._build_panel())
@@ -138,9 +149,12 @@ class ClientViewLayer:
             except KeyboardInterrupt:
                 running = False
             task.cancel()
+            tick_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+                await tick_task
         await self.service.close()
+        os.system("cls" if os.name == "nt" else "clear")
 
     def _current_id(self) -> str | None:
         if not self.service.state:


### PR DESCRIPTION
## Summary
- add auto tick loop and screen clearing in `ClientViewLayer`
- ensure TUI updates timers each second and clears terminal on exit

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f4ce40e248330a7091e37db9235ab