### PR TITLE
Implement batch timer operations

### DIFF
--- a/mytimer/client/controller.py
+++ b/mytimer/client/controller.py
@@ -75,20 +75,17 @@ def _get_timers(base_url: str) -> dict[str, Any]:
 
 
 def pause_all_timers(base_url: str) -> None:
-    for tid in _get_timers(base_url).keys():
-        requests.post(f"{base_url}/timers/{tid}/pause", timeout=5).raise_for_status()
+    requests.post(f"{base_url}/timers/pause_all", timeout=5).raise_for_status()
     print("paused all")
 
 
 def resume_all_timers(base_url: str) -> None:
-    for tid in _get_timers(base_url).keys():
-        requests.post(f"{base_url}/timers/{tid}/resume", timeout=5).raise_for_status()
+    requests.post(f"{base_url}/timers/resume_all", timeout=5).raise_for_status()
     print("resumed all")
 
 
 def remove_all_timers(base_url: str) -> None:
-    for tid in list(_get_timers(base_url).keys()):
-        requests.delete(f"{base_url}/timers/{tid}", timeout=5).raise_for_status()
+    requests.delete(f"{base_url}/timers", timeout=5).raise_for_status()
     print("removed all")
 
 

--- a/mytimer/client/input_handler.py
+++ b/mytimer/client/input_handler.py
@@ -74,20 +74,17 @@ async def _get_timers(service: "SyncService") -> dict[str, Any]:
 
 
 async def pause_all_timers(service: "SyncService") -> None:
-    for tid in (await _get_timers(service)).keys():
-        await service.pause_timer(int(tid))
+    await service.pause_all()
     print("paused all")
 
 
 async def resume_all_timers(service: "SyncService") -> None:
-    for tid in (await _get_timers(service)).keys():
-        await service.resume_timer(int(tid))
+    await service.resume_all()
     print("resumed all")
 
 
 async def remove_all_timers(service: "SyncService") -> None:
-    for tid in list((await _get_timers(service)).keys()):
-        await service.remove_timer(int(tid))
+    await service.remove_all_timers()
     print("removed all")
 
 

--- a/mytimer/client/sync_service.py
+++ b/mytimer/client/sync_service.py
@@ -153,6 +153,18 @@ class SyncService:
         resp = await self.client.delete(f"/timers/{timer_id}")
         resp.raise_for_status()
 
+    async def remove_all_timers(self) -> None:
+        resp = await self.client.delete("/timers")
+        resp.raise_for_status()
+
+    async def pause_all(self) -> None:
+        resp = await self.client.post("/timers/pause_all")
+        resp.raise_for_status()
+
+    async def resume_all(self) -> None:
+        resp = await self.client.post("/timers/resume_all")
+        resp.raise_for_status()
+
     async def tick(self, seconds: float) -> None:
         resp = await self.client.post("/tick", params={"seconds": seconds})
         resp.raise_for_status()

--- a/mytimer/server/api.py
+++ b/mytimer/server/api.py
@@ -132,12 +132,28 @@ async def remove_timer(timer_id: int):
     return JSONResponse(status_code=200, content={"status": "removed"})
 
 
+@app.delete("/timers")
+async def remove_all_timers():
+    """Delete all timers managed by the server."""
+    manager.remove_all()
+    await broadcast_state()
+    return {"status": "all_removed"}
+
+
 @app.post("/timers/pause_all")
 async def pause_all_timers():
     """Pause all running timers."""
     manager.pause_all()
     await broadcast_state()
     return {"status": "all_paused"}
+
+
+@app.post("/timers/resume_all")
+async def resume_all_timers():
+    """Resume all paused timers."""
+    manager.resume_all()
+    await broadcast_state()
+    return {"status": "all_resumed"}
 
 
 @app.post("/timers/reset_all")

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -98,6 +98,15 @@ def test_pause_all_and_reset_all():
         assert t['remaining'] == t['duration']
         assert t['running'] and not t['finished']
 
+    resp = client.post('/timers/resume_all')
+    assert resp.status_code == 200
+    resumed = client.get('/timers').json()
+    assert all(t['running'] for t in resumed.values())
+
+    resp = client.delete('/timers')
+    assert resp.status_code == 200
+    assert client.get('/timers').json() == {}
+
 
 def test_server_status():
     client.post('/timers', params={'duration': 5})


### PR DESCRIPTION
## Summary
- add new server endpoints for resume_all and remove_all timers
- expose pause_all/resume_all/remove_all helpers in SyncService
- update CLI controller and input handler to use new API endpoints
- test batch operations through updated API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c85ca25f88330a462f5bd99149586