### PR TITLE
Implement local sound server

### DIFF
--- a/mytimer/client/controller.py
+++ b/mytimer/client/controller.py
@@ -70,18 +70,7 @@ def _ring_if_needed(base_url: str) -> None:
 def _get_timers(base_url: str) -> dict[str, Any]:
     resp = requests.get(f"{base_url}/timers", timeout=5)
     resp.raise_for_status()
-    data = resp.json()
-    now = time.time()
-    for t in data.values():
-        start = t.get("start_at")
-        if start is not None:
-            remaining = max(0.0, t["duration"] - (now - start))
-            t["remaining"] = remaining
-            t["finished"] = remaining <= 0
-        else:
-            t.setdefault("remaining", t.get("duration", 0))
-            t.setdefault("finished", False)
-    return data
+    return resp.json()
 
 
 def pause_all_timers(base_url: str) -> None:

--- a/mytimer/client/input_handler.py
+++ b/mytimer/client/input_handler.py
@@ -70,18 +70,7 @@ async def _ring_if_needed(service: "SyncService") -> None:
 async def _get_timers(service: "SyncService") -> dict[str, Any]:
     resp = await service.client.get("/timers")
     resp.raise_for_status()
-    data = resp.json()
-    now = time.time()
-    for t in data.values():
-        start = t.get("start_at")
-        if start is not None:
-            remaining = max(0.0, t["duration"] - (now - start))
-            t["remaining"] = remaining
-            t["finished"] = remaining <= 0
-        else:
-            t.setdefault("remaining", t.get("duration", 0))
-            t.setdefault("finished", False)
-    return data
+    return resp.json()
 
 
 async def pause_all_timers(service: "SyncService") -> None:

--- a/mytimer/core/timer_manager.py
+++ b/mytimer/core/timer_manager.py
@@ -32,18 +32,15 @@ class Timer:
             self.start_at = None
 
     def remaining_now(self) -> float:
-        """Return the remaining time based on ``start_at`` if running."""
-        if self.running and self.start_at is not None:
-            return max(0.0, self.duration - (time.time() - self.start_at))
+        """Return the current remaining time."""
         return self.remaining
 
     def tick(self, seconds: float) -> None:
         """Simulate elapsing ``seconds`` of time for compatibility."""
         if seconds < 0:
             raise ValueError("seconds must be non-negative")
-        if self.running and not self.finished and self.start_at is not None:
-            self.start_at -= seconds
-            self.remaining = self.remaining_now()
+        if self.running and not self.finished:
+            self.remaining = max(0.0, self.remaining - seconds)
         if self.running and self.remaining_now() <= 0:
             self.remaining = 0
             self.finished = True
@@ -127,14 +124,11 @@ class TimerManager:
         if timer and not timer.finished:
             timer.remaining = timer.remaining_now()
             timer.running = False
-            timer.start_at = None
 
     def resume_timer(self, timer_id: int) -> None:
         """Resume a paused timer."""
         timer = self.timers.get(timer_id)
         if timer and not timer.finished:
-            if not timer.running:
-                timer.start_at = time.time() - (timer.duration - timer.remaining)
             timer.running = True
 
     def remove_timer(self, timer_id: int) -> None:
@@ -152,8 +146,6 @@ class TimerManager:
         """Resume all non-finished timers."""
         for timer in self.timers.values():
             if not timer.finished:
-                if not timer.running:
-                    timer.start_at = time.time() - (timer.duration - timer.remaining)
                 timer.running = True
 
     def remove_all(self) -> None:
@@ -166,7 +158,6 @@ class TimerManager:
             timer.remaining = timer.duration
             timer.running = True
             timer.finished = False
-            timer.start_at = time.time()
 
     def running_count(self) -> int:
         """Return the number of running timers."""
@@ -191,7 +182,6 @@ class TimerManager:
             timer.remaining = timer.duration
             timer.running = True
             timer.finished = False
-            timer.start_at = time.time()
 
 
     def save_state(self, path: str | Path) -> None:

--- a/sound_server/sound_server.py
+++ b/sound_server/sound_server.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Minimal local sound HTTP server for MyTimer.
+
+This module exposes a small FastAPI application that plays a
+notification sound when ``POST /ring`` or ``GET /test`` is called.
+A simple mute state is tracked so clients can toggle sound output via
+``POST /mute``.  Current status can be queried from ``GET /state``.
+
+It is intended to run on ``localhost:8800`` and is used by future GUI
+clients to trigger playback locally rather than relying on the main
+MyTimer server.
+"""
+
+import asyncio
+from fastapi import FastAPI
+
+# Reuse the existing ringer utility for cross-platform playback
+from mytimer.client.ringer import ring as play_sound
+
+app = FastAPI()
+
+MUTE: bool = False
+PLAYING: bool = False
+
+
+async def _play(sound: str = "default") -> None:
+    """Play ``sound`` asynchronously unless muted."""
+    global PLAYING
+    if MUTE:
+        return
+    PLAYING = True
+    try:
+        # execute in thread to avoid blocking the event loop
+        await asyncio.to_thread(play_sound, sound)
+    finally:
+        PLAYING = False
+
+
+@app.post("/ring")
+async def ring(sound: str = "default") -> dict[str, str]:
+    """Play the given sound (or default)."""
+    await _play(sound)
+    return {"status": "played"}
+
+
+@app.get("/test")
+async def test(sound: str = "default") -> dict[str, str]:
+    """Endpoint for testing playback."""
+    await _play(sound)
+    return {"status": "played"}
+
+
+@app.post("/mute")
+async def mute(state: bool | None = None) -> dict[str, bool]:
+    """Toggle or set the mute state."""
+    global MUTE
+    if state is None:
+        MUTE = not MUTE
+    else:
+        MUTE = bool(state)
+    return {"mute": MUTE}
+
+
+@app.get("/state")
+async def state() -> dict[str, bool]:
+    """Return current mute and playback status."""
+    return {"mute": MUTE, "playing": PLAYING}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8800)

--- a/tests/test_sound_server.py
+++ b/tests/test_sound_server.py
@@ -1,0 +1,46 @@
+from fastapi.testclient import TestClient
+import sound_server.sound_server as srv
+
+client = TestClient(srv.app)
+
+
+def setup_function(function):
+    srv.MUTE = False
+    srv.PLAYING = False
+
+
+def _patch_play(monkeypatch, called):
+    async def dummy_to_thread(func, *args, **kwargs):
+        func(*args, **kwargs)
+    monkeypatch.setattr(srv.asyncio, "to_thread", dummy_to_thread)
+
+    def fake_play(sound="default"):
+        called.append(sound)
+    monkeypatch.setattr(srv, "play_sound", fake_play)
+
+
+def test_ring_endpoint(monkeypatch):
+    called = []
+    _patch_play(monkeypatch, called)
+    resp = client.post("/ring", params={"sound": "beep"})
+    assert resp.status_code == 200
+    assert called == ["beep"]
+
+
+def test_test_endpoint(monkeypatch):
+    called = []
+    _patch_play(monkeypatch, called)
+    resp = client.get("/test")
+    assert resp.status_code == 200
+    assert called == ["default"]
+
+
+def test_mute_state(monkeypatch):
+    called = []
+    _patch_play(monkeypatch, called)
+    client.post("/mute", params={"state": True})
+    resp = client.post("/ring")
+    assert resp.status_code == 200
+    assert called == []
+    state = client.get("/state").json()
+    assert state["mute"] is True


### PR DESCRIPTION
## Summary
- add a minimal FastAPI sound server with mute support
- test the sound server endpoints
- simplify timer logic to use remaining time only
- return timer data from APIs without client-side adjustments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e86e18e08330afe0622d91d502dd