### PR TITLE
Complete task 8C

### DIFF
--- a/mytimer/__init__.py
+++ b/mytimer/__init__.py
@@ -1,0 +1,6 @@
+"""MyTimer package initialization."""
+
+import os
+
+# Disable HTTPie network update checks during tests or CLI usage
+os.environ.setdefault("HTTPIE_DISABLE_UPGRADE_CHECK", "1")

--- a/mytimer/client/controller.py
+++ b/mytimer/client/controller.py
@@ -56,12 +56,20 @@ def _load_settings() -> ClientSettings:
 
 def _ring_if_needed(base_url: str) -> None:
     settings = _load_settings()
-    if not settings.notifications_enabled or not sys.stdout.isatty():
+    if (
+        not settings.notifications_enabled
+        or not sys.stdout.isatty()
+        or settings.mute
+        or settings.volume <= 0
+    ):
         return
     try:
         for t in _get_timers(base_url).values():
             if t.get("finished"):
-                ring(settings.notify_sound, settings.volume, settings.mute)
+                try:
+                    requests.post("http://127.0.0.1:8800/ring", timeout=0.1)
+                except Exception:
+                    ring(settings.notify_sound, settings.volume, settings.mute)
                 break
     except requests.RequestException:
         pass

--- a/tests/test_ring_if_needed.py
+++ b/tests/test_ring_if_needed.py
@@ -2,6 +2,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import pytest
+import httpx
 from client_settings import ClientSettings
 from mytimer.client import input_handler
 
@@ -22,26 +23,44 @@ class DummyService:
         self.client = DummyClient()
 
 @pytest.mark.asyncio
-async def test_ring_if_needed_beeps(monkeypatch, capsys):
+async def test_ring_if_needed_beeps(monkeypatch):
     monkeypatch.setattr(
         input_handler,
         "_load_settings",
         lambda: ClientSettings(notifications_enabled=True, volume=1.0, mute=False),
     )
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    called = []
+
+    async def fake_post(self, url, **kwargs):
+        called.append(url)
+        class Resp:
+            def raise_for_status(self):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
     await input_handler._ring_if_needed(DummyService())
-    captured = capsys.readouterr()
-    assert "\a" in captured.out
+    assert called == ["http://127.0.0.1:8800/ring"]
 
 
 @pytest.mark.asyncio
-async def test_ring_if_needed_muted(monkeypatch, capsys):
+async def test_ring_if_needed_muted(monkeypatch):
     monkeypatch.setattr(
         input_handler,
         "_load_settings",
         lambda: ClientSettings(notifications_enabled=True, mute=True),
     )
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    called = []
+
+    async def fake_post(self, url, **kwargs):
+        called.append(url)
+        class Resp:
+            def raise_for_status(self):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
     await input_handler._ring_if_needed(DummyService())
-    captured = capsys.readouterr()
-    assert "\a" not in captured.out
+    assert called == []


### PR DESCRIPTION
## Summary
- trigger local sound server when timers finish
- respect mute/volume and skip if disabled
- add env var to disable HTTPie update checks
- test ring helpers accordingly

## Testing
- `pytest -q` *(fails: assert data[str(tid1)]["remaining"] == pytest.approx(3, abs=1.0))*

------
https://chatgpt.com/codex/tasks/task_e_6889e86aa06c8330b78c22252bd3c106