### PR TITLE
Add optional GUI tests for Qt client

### DIFF
--- a/qt_client/__init__.py
+++ b/qt_client/__init__.py
@@ -1,5 +1,16 @@
-"""PyQt6 GUI client for MyTimer."""
+"""PyQt6 GUI client for MyTimer.
 
-from .main import main
+Importing this package does not require the Qt bindings until ``main()`` is
+invoked.  This allows lightweight modules like ``network_client`` to be used
+without a full Qt environment available."""
+
+from importlib import import_module
+
+
+def main() -> None:
+    """Entry point that lazily imports and executes ``qt_client.main``."""
+
+    import_module(".main", __name__).main()
+
 
 __all__ = ["main"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ rich
 psutil
 websockets
 pytest-cov
+PyQt6

--- a/tests/test_qt_gui_mainwindow.py
+++ b/tests/test_qt_gui_mainwindow.py
@@ -1,0 +1,84 @@
+import os
+import time
+import pytest
+pytest.importorskip("PyQt6.QtWidgets")
+from PyQt6 import QtWidgets, QtCore
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from qt_client import gui_mainwindow
+
+
+class DummyClient:
+    def __init__(self, data):
+        self.data = data
+        self.created = []
+
+    def list_timers(self):
+        return self.data
+
+    def create_timer(self, dur):
+        self.created.append(dur)
+        return '1'
+
+
+class DummySound:
+    def __init__(self):
+        self.rings = 0
+
+    def ring(self):
+        self.rings += 1
+
+
+def _patch_timer(monkeypatch):
+    class DummySignal:
+        def connect(self, *args, **kwargs):
+            pass
+
+    class DummyTimer:
+        def __init__(self, *args, **kwargs):
+            self.timeout = DummySignal()
+
+        def start(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(gui_mainwindow.QtCore, 'QTimer', DummyTimer)
+
+
+def test_refresh_updates_table(monkeypatch):
+    _patch_timer(monkeypatch)
+    data = {'1': {'duration': 5, 'start_at': time.time() - 2}}
+    client = DummyClient(data)
+    sound = DummySound()
+    app = QtWidgets.QApplication([])
+    win = gui_mainwindow.MainWindow(client=client, sound=sound)
+    win.refresh()
+    assert win.table.rowCount() == 1
+    remaining = float(win.table.item(0, 3).text())
+    assert 2.0 <= remaining <= 3.0
+
+
+def test_ring_on_finish(monkeypatch):
+    _patch_timer(monkeypatch)
+    now = time.time()
+    data = {'1': {'duration': 1, 'start_at': now - 2}}
+    client = DummyClient(data)
+    sound = DummySound()
+    app = QtWidgets.QApplication([])
+    win = gui_mainwindow.MainWindow(client=client, sound=sound)
+    win.refresh()
+    assert sound.rings == 1
+
+
+def test_create_timer_dialog(monkeypatch):
+    _patch_timer(monkeypatch)
+    client = DummyClient({})
+    sound = DummySound()
+    app = QtWidgets.QApplication([])
+    monkeypatch.setattr(QtWidgets.QInputDialog, 'getDouble', lambda *a, **k: (3.0, True))
+    monkeypatch.setattr(QtWidgets.QInputDialog, 'getText', lambda *a, **k: ('tag', True))
+    win = gui_mainwindow.MainWindow(client=client, sound=sound)
+    win.create_timer_dialog()
+    assert client.created == [3.0]
+    assert win.tags['1'] == 'tag'
+

--- a/tests/test_qt_gui_tray.py
+++ b/tests/test_qt_gui_tray.py
@@ -1,0 +1,67 @@
+import os
+import pytest
+pytest.importorskip("PyQt6.QtWidgets")
+from PyQt6 import QtWidgets, QtGui
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from qt_client.gui_tray import TrayIcon
+
+
+class DummyWindow:
+    def __init__(self):
+        self.create_count = 0
+
+    def create_timer_dialog(self):
+        self.create_count += 1
+
+    def show(self):
+        pass
+
+    def hide(self):
+        pass
+
+    def raise_(self):
+        pass
+
+    def isVisible(self):
+        return False
+
+
+class DummyApp(QtWidgets.QApplication):
+    def __init__(self):
+        super().__init__([])
+        self.quit_called = False
+
+    def quit(self):
+        self.quit_called = True
+
+
+def test_tray_actions(monkeypatch):
+    monkeypatch.setattr(QtGui.QIcon, 'fromTheme', lambda *a, **k: QtGui.QIcon())
+    monkeypatch.setattr(TrayIcon, 'show', lambda self: None)
+    toggle = []
+    monkeypatch.setattr(TrayIcon, 'toggle_window', lambda self: toggle.append(True))
+    app = DummyApp()
+    window = DummyWindow()
+    tray = TrayIcon(window, app)
+    actions = tray.contextMenu().actions()
+    actions[0].trigger()  # Show/Hide
+    assert toggle == [True]
+    actions[1].trigger()  # Add Timer
+    assert window.create_count == 1
+    actions[3].trigger()  # Quit
+    assert app.quit_called
+
+
+def test_tray_activate(monkeypatch):
+    monkeypatch.setattr(QtGui.QIcon, 'fromTheme', lambda *a, **k: QtGui.QIcon())
+    monkeypatch.setattr(TrayIcon, 'show', lambda self: None)
+    toggle = []
+    monkeypatch.setattr(TrayIcon, 'toggle_window', lambda self: toggle.append(True))
+    app = DummyApp()
+    window = DummyWindow()
+    tray = TrayIcon(window, app)
+    tray._on_activate(QtWidgets.QSystemTrayIcon.ActivationReason.Trigger)
+    assert toggle == [True]
+

--- a/tests/test_qt_main.py
+++ b/tests/test_qt_main.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+pytest.importorskip("PyQt6.QtWidgets")
+from PyQt6 import QtWidgets
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+import qt_client.main as main
+
+
+def test_main_runs(monkeypatch):
+    created = {}
+
+    class DummyApp(QtWidgets.QApplication):
+        def __init__(self, *a, **k):
+            super().__init__([])
+            created['app'] = True
+
+        def exec(self):
+            created['exec'] = True
+            return 0
+
+    class DummyWindow:
+        def show(self):
+            created['show'] = True
+
+    class DummyTray:
+        def __init__(self, window, app):
+            created['tray'] = True
+
+    monkeypatch.setattr(main.QtWidgets, 'QApplication', DummyApp)
+    monkeypatch.setattr(main, 'MainWindow', lambda: DummyWindow())
+    monkeypatch.setattr(main, 'TrayIcon', DummyTray)
+    main.main()
+    assert created == {'app': True, 'show': True, 'tray': True, 'exec': True}
+

--- a/tests/test_qt_network_client.py
+++ b/tests/test_qt_network_client.py
@@ -1,0 +1,43 @@
+import subprocess
+import time
+import requests
+import pytest
+
+from qt_client.network_client import NetworkClient
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_api():
+    proc = subprocess.Popen([
+        "uvicorn",
+        "mytimer.server.api:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8011",
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    for _ in range(10):
+        try:
+            requests.get("http://127.0.0.1:8011/timers", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.5)
+    else:
+        proc.terminate()
+        proc.wait()
+        raise RuntimeError("API server failed to start")
+    yield
+    proc.terminate()
+    proc.wait()
+
+
+def test_network_client_flow(start_api):
+    client = NetworkClient("http://127.0.0.1:8011")
+    tid = client.create_timer(2)
+    data = client.list_timers()
+    assert str(tid) in data
+    client.pause_timer(tid)
+    client.resume_timer(tid)
+    data = client.list_timers()
+    assert data[str(tid)]["duration"] == 2
+

--- a/tests/test_qt_sound_client.py
+++ b/tests/test_qt_sound_client.py
@@ -1,0 +1,28 @@
+import requests
+import pytest
+
+from qt_client.sound_client import SoundClient
+
+
+def test_sound_client_posts(monkeypatch):
+    called = {}
+
+    def fake_post(url, timeout=3):
+        called['url'] = url
+        class Resp:
+            status_code = 200
+        return Resp()
+
+    monkeypatch.setattr(requests, 'post', fake_post)
+    sc = SoundClient('http://host:8800')
+    sc.ring()
+    assert called['url'] == 'http://host:8800/ring'
+
+
+def test_sound_client_ignores_errors(monkeypatch):
+    def fake_post(url, timeout=3):
+        raise requests.RequestException('fail')
+    monkeypatch.setattr(requests, 'post', fake_post)
+    sc = SoundClient('http://host:8800')
+    sc.ring()  # should not raise
+


### PR DESCRIPTION
## Summary
- enable lazy import for qt_client to avoid PyQt requirement during module import
- add `PyQt6` to requirements
- add test suite covering NetworkClient, SoundClient, MainWindow, TrayIcon and main entry point
- mark GUI tests as optional with `importorskip` so they are skipped when PyQt6 is unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f308a6948330af57d6141ce0d07c