### PR TITLE
Fix timer start_at handling and tray icon

### DIFF
--- a/finished_task/task8.md
+++ b/finished_task/task8.md
@@ -1,0 +1,8 @@
+# Task 8 Verification
+
+The Qt GUI, local sound server and timestamp based architecture were implemented for Task 8. During review I found two issues:
+
+1. `start_at` was not updated when timers were paused or resumed. Clients computing remaining time using the timestamp would show incorrect values after resuming. The pause/resume methods (and their batch variants) now clear or reset `start_at` so resumed timers use the current time.
+2. The tray icon object created in `qt_client.main` had no reference, allowing it to be garbage collected. A persistent reference is now stored on the Qt application.
+
+A regression test covering the `start_at` logic was added and all tests pass.

--- a/mytimer/core/timer_manager.py
+++ b/mytimer/core/timer_manager.py
@@ -121,15 +121,17 @@ class TimerManager:
     def pause_timer(self, timer_id: int) -> None:
         """Pause the specified timer."""
         timer = self.timers.get(timer_id)
-        if timer and not timer.finished:
+        if timer and not timer.finished and timer.running:
             timer.remaining = timer.remaining_now()
             timer.running = False
+            timer.start_at = None
 
     def resume_timer(self, timer_id: int) -> None:
         """Resume a paused timer."""
         timer = self.timers.get(timer_id)
-        if timer and not timer.finished:
+        if timer and not timer.finished and not timer.running:
             timer.running = True
+            timer.start_at = time.time()
 
     def remove_timer(self, timer_id: int) -> None:
         """Remove a timer from the registry."""
@@ -138,15 +140,17 @@ class TimerManager:
     def pause_all(self) -> None:
         """Pause all running timers."""
         for timer in self.timers.values():
-            if not timer.finished:
+            if not timer.finished and timer.running:
                 timer.remaining = timer.remaining_now()
                 timer.running = False
+                timer.start_at = None
                 
     def resume_all(self) -> None:
         """Resume all non-finished timers."""
         for timer in self.timers.values():
-            if not timer.finished:
+            if not timer.finished and not timer.running:
                 timer.running = True
+                timer.start_at = time.time()
 
     def remove_all(self) -> None:
         """Remove all timers from the manager."""
@@ -158,6 +162,7 @@ class TimerManager:
             timer.remaining = timer.duration
             timer.running = True
             timer.finished = False
+            timer.start_at = time.time()
 
     def running_count(self) -> int:
         """Return the number of running timers."""
@@ -182,6 +187,7 @@ class TimerManager:
             timer.remaining = timer.duration
             timer.running = True
             timer.finished = False
+            timer.start_at = time.time()
 
 
     def save_state(self, path: str | Path) -> None:

--- a/qt_client/main.py
+++ b/qt_client/main.py
@@ -9,7 +9,9 @@ from .gui_tray import TrayIcon
 def main() -> None:
     app = QtWidgets.QApplication([])
     window = MainWindow()
-    TrayIcon(window, app)
+    tray = TrayIcon(window, app)
+    # keep a reference to avoid premature garbage collection
+    app.tray = tray
     window.show()
     app.exec()
 

--- a/tests/test_start_at_resume.py
+++ b/tests/test_start_at_resume.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from mytimer.core.timer_manager import TimerManager
+
+
+def test_start_at_updates_on_pause_resume(monkeypatch):
+    fake_times = [100.0, 101.0, 102.0, 103.0]
+
+    def fake_time():
+        return fake_times.pop(0)
+
+    monkeypatch.setattr("mytimer.core.timer_manager.time.time", fake_time)
+    tm = TimerManager()
+    tid = tm.create_timer(5)
+    original = tm.timers[tid].start_at
+    tm.pause_timer(tid)
+    assert tm.timers[tid].start_at is None
+    tm.resume_timer(tid)
+    assert tm.timers[tid].start_at > original


### PR DESCRIPTION
## Summary
- update timer pause/resume functions to maintain start_at
- ensure batch operations also adjust start_at
- keep reference to Qt tray icon
- add regression test for start_at logic
- document verification in task8 summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889f2abd8a083308b4d7f31cc2b1648