### PR TITLE
Fix timer tick progression and add GUI client tests

### DIFF
--- a/tests/test_qt_clients.py
+++ b/tests/test_qt_clients.py
@@ -1,0 +1,35 @@
+import time
+import types
+import pytest
+
+import qt_client.network_client as nc
+import qt_client.sound_client as sc
+
+
+def test_network_client_computes_remaining(monkeypatch):
+    now = time.time()
+    data = {"1": {"duration": 5, "start_at": now - 2}}
+
+    class DummyResp:
+        def json(self):
+            return data
+        def raise_for_status(self):
+            pass
+
+    session = types.SimpleNamespace(get=lambda url, timeout: DummyResp())
+    client = nc.NetworkClient("http://testserver")
+    client.session = session
+    result = client.list_timers()
+    remaining = result["1"]["remaining"]
+    assert 2.0 <= remaining <= 3.0
+    assert not result["1"]["finished"]
+
+
+def test_sound_client_posts(monkeypatch):
+    called = {}
+    def fake_post(url, timeout):
+        called["url"] = url
+    monkeypatch.setattr(sc.requests, "post", fake_post)
+    client = sc.SoundClient("http://local")
+    client.ring()
+    assert called["url"] == "http://local/ring"


### PR DESCRIPTION
## Summary
- adjust timer tick to fast-forward `start_at` so remaining time updates correctly
- preserve remaining time when resuming timers
- add tests for Qt network and sound clients

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad6a1f30c8330835f879d9a404c16