### PR TITLE
Fix timer tick timestamp and extend Qt GUI tests

### DIFF
--- a/mytimer/core/timer_manager.py
+++ b/mytimer/core/timer_manager.py
@@ -41,6 +41,8 @@ class Timer:
             raise ValueError("seconds must be non-negative")
         if self.running and not self.finished:
             self.remaining = max(0.0, self.remaining - seconds)
+            if self.start_at is not None:
+                self.start_at -= seconds
         if self.running and self.remaining_now() <= 0:
             self.remaining = 0
             self.finished = True

--- a/tests/test_qt_gui_mainwindow.py
+++ b/tests/test_qt_gui_mainwindow.py
@@ -1,7 +1,7 @@
 import os
 import time
 import pytest
-pytest.importorskip("PyQt6.QtWidgets")
+pytest.importorskip("PyQt6.QtWidgets", exc_type=ImportError)
 from PyQt6 import QtWidgets, QtCore
 
 os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
@@ -81,4 +81,20 @@ def test_create_timer_dialog(monkeypatch):
     win.create_timer_dialog()
     assert client.created == [3.0]
     assert win.tags['1'] == 'tag'
+
+
+def test_refresh_sorts_by_id(monkeypatch):
+    _patch_timer(monkeypatch)
+    now = time.time()
+    data = {
+        '2': {'duration': 1, 'start_at': now},
+        '1': {'duration': 1, 'start_at': now},
+    }
+    client = DummyClient(data)
+    sound = DummySound()
+    app = QtWidgets.QApplication([])
+    win = gui_mainwindow.MainWindow(client=client, sound=sound)
+    win.refresh()
+    ids = [win.table.item(i, 0).text() for i in range(win.table.rowCount())]
+    assert ids == ['1', '2']
 

--- a/tests/test_qt_gui_tray.py
+++ b/tests/test_qt_gui_tray.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-pytest.importorskip("PyQt6.QtWidgets")
+pytest.importorskip("PyQt6.QtWidgets", exc_type=ImportError)
 from PyQt6 import QtWidgets, QtGui
 
 os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')

--- a/tests/test_qt_main.py
+++ b/tests/test_qt_main.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-pytest.importorskip("PyQt6.QtWidgets")
+pytest.importorskip("PyQt6.QtWidgets", exc_type=ImportError)
 from PyQt6 import QtWidgets
 
 os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')


### PR DESCRIPTION
## Summary
- Correct timer tick logic to keep `start_at` in sync with remaining time
- Add GUI test ensuring table rows sort by timer ID
- Improve Qt test skips by explicitly handling ImportError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ad6a1f30c8330835f879d9a404c16