### PR TITLE
Gracefully handle invalid volume in client settings

### DIFF
--- a/client_settings.py
+++ b/client_settings.py
@@ -35,6 +35,11 @@ class ClientSettings:
         except (json.JSONDecodeError, OSError):
             return cls()
 
+        try:
+            volume = float(data.get("volume", cls.volume))
+        except (TypeError, ValueError):
+            volume = cls.volume
+
         return cls(
             server_url=data.get("server_url", cls.server_url),
             notifications_enabled=data.get(
@@ -44,7 +49,7 @@ class ClientSettings:
             auth_token=data.get("auth_token"),
             device_name=data.get("device_name"),
             theme=data.get("theme", cls.theme),
-            volume=float(data.get("volume", cls.volume)),
+            volume=volume,
             mute=bool(data.get("mute", cls.mute)),
         )
 

--- a/tests/test_client_settings.py
+++ b/tests/test_client_settings.py
@@ -99,3 +99,10 @@ def test_import_export_json(tmp_path):
     assert loaded.auth_token == "tok"
     assert loaded.device_name == "name"
 
+
+def test_load_invalid_volume_returns_default(tmp_path):
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"volume": "loud"}))
+    settings = ClientSettings.load(path)
+    assert settings.volume == 1.0
+


### PR DESCRIPTION
## Summary
- Harden ClientSettings.load against invalid volume entries by falling back to default when conversion fails
- Add regression test ensuring invalid volume values are ignored and default is used

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c5057ce8483308dc20179e2a824d6